### PR TITLE
#30/ci testing

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,0 +1,16 @@
+name: CI Jest
+on:
+  pull_request:
+    branches: ["dev", "main"]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - name: Install modules
+        run: pnpm install
+      - name: Run Tests
+        run: pnpm test

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -11,7 +11,7 @@ const tsconfig = require("./tsconfig.json")
 const config = {
   setupFiles: ["jest-webextension-mock"],
   extensionsToTreatAsEsm: [".ts", ".tsx"],
-  testRegex: ["^.+\\.test.tsx?$"],
+  testRegex: ["^.+\\.test.jsx?$"],
   moduleNameMapper: pathsToModuleNameMapper(
     tsconfig.compilerOptions.paths,
     {

--- a/src/__tests__/fetchCurrentProject.test.js
+++ b/src/__tests__/fetchCurrentProject.test.js
@@ -1,8 +1,6 @@
 import { describe, expect, it, jest, beforeEach } from "@jest/globals"
 import fetchMock from "jest-fetch-mock"
 
-import type { PlasmoMessaging } from "@plasmohq/messaging"
-
 import * as testData from "../../test-data.json"
 import handler from "../background/messages/fetchCurrentProject"
 
@@ -16,11 +14,11 @@ describe("fetchCurrentProject", () => {
   it("returns a project object to the front from our api", async () => {
     fetchMock.mockResponseOnce(JSON.stringify(testData))
 
-    const req: PlasmoMessaging.Request = {
+    const req= {
       name: "fetchCurrentProject"
     }
 
-    const res: PlasmoMessaging.Response = {
+    const res = {
       send: jest.fn()
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "plasmo/templates/tsconfig.base",
   "exclude": ["node_modules"],
-  "include": [".plasmo/index.d.ts", "./**/*.ts", "./**/*.tsx", "src/store/store.test.ts", "src/background/messages/set_context.test.ts"],
+  "include": [".plasmo/index.d.ts", "./**/*.ts", "./**/*.tsx", "src/store/store.test.ts", "src/background/messages/set_context.test.ts", "src/__tests__/fetchCurrentProject.test.js"],
   "compilerOptions": {
     "paths": {
       "~*": ["./src/*"]


### PR DESCRIPTION
# Description

**Closes #30**  

created workflow to run Jest suites on any pr targeting `dev` or `main`

### Files changed

- `.github/workflows/jest.yml` - new workflow file
- `__tests__/fetchCurrentProject.js` - changed from `.ts` to `.js` because in the ci there were type errors coming up from our mocking of fetch, which tried to turn an implicit `any` to a `never`
- `jest.config.js`, `tsconfig.json` - config changes to allow the above swap to work

### UI changes

n/a

### Changes to Documentation

n/a

# Tests

tests should be running on this PR 😬 
