### PR TITLE
#71/fix set event alarm 

### DIFF
--- a/src/background/messages/updateEventAlarm.ts
+++ b/src/background/messages/updateEventAlarm.ts
@@ -4,10 +4,10 @@ import setEventAlarm from "~utils/setEventAlarm"
 
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   const { eventHour, eventMinute } = req.body
-  const newAlarm = setEventAlarm(eventHour, eventMinute)
-  if (!newAlarm)
-    res.send({ data: null, error: "Could not set new alarm" })
-  res.send({ data: newAlarm, error: null })
+  const {data, error} = await setEventAlarm(eventHour, eventMinute)
+  if (error)
+    res.send({ data: null, error: error })
+  res.send({ data: data, error: null })
 }
 
 export default handler

--- a/src/background/messages/updateEventAlarm.ts
+++ b/src/background/messages/updateEventAlarm.ts
@@ -2,10 +2,12 @@ import type { PlasmoMessaging } from "@plasmohq/messaging"
 
 import setEventAlarm from "~utils/setEventAlarm"
 
-const handler: PlasmoMessaging.MessageHandler = async req => {
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   const { eventHour, eventMinute } = req.body
-
-  setEventAlarm(eventHour, eventMinute)
+  const newAlarm = setEventAlarm(eventHour, eventMinute)
+  if (!newAlarm)
+    res.send({ data: null, error: "Could not set new alarm" })
+  res.send({ data: newAlarm, error: null })
 }
 
 export default handler

--- a/src/background/messages/updateUserDetails.ts
+++ b/src/background/messages/updateUserDetails.ts
@@ -15,7 +15,7 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   const response = await fetchStrapiContent<User>(
     `api/users/${userSession.id}`,
     "PUT",
-    "fakejwt",
+    userSession.jwt,
     JSON.stringify({
       ...newDetails
     })

--- a/src/background/messages/updateUserDetails.ts
+++ b/src/background/messages/updateUserDetails.ts
@@ -15,7 +15,7 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   const response = await fetchStrapiContent<User>(
     `api/users/${userSession.id}`,
     "PUT",
-    userSession.jwt,
+    "fakejwt",
     JSON.stringify({
       ...newDetails
     })
@@ -23,6 +23,7 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
 
   if (response.error) {
     console.error(response.error)
+    res.send(response)
   }
 
   const newSession = updateStorage(userSession, {

--- a/src/components/page-components/ProfilePage/ProfilePage.tsx
+++ b/src/components/page-components/ProfilePage/ProfilePage.tsx
@@ -58,7 +58,7 @@ export default function ProfilePage() {
         name: "updateUserDetails",
         body: { is_paused: !isPaused }
       })
-    if (error) setPausedStateError(error)
+    if (error) setPausedStateError("Something went wrong. Please try again later.")
     updatedIsPaused(!isPaused)
 
     if (!isPaused) {
@@ -68,7 +68,7 @@ export default function ProfilePage() {
         name: "updateEventAlarm",
         body: { eventHour: selectedHour, eventMinute: selectedMinute }
       })
-      if (error) setPausedStateError(error)
+      if (error) setPausedStateError("Something went wrong. Please try again later.")
     } else {
       await sendToBackground({ name: "removeEventAlarm" })
     }

--- a/src/components/page-components/ProfilePage/ProfilePage.tsx
+++ b/src/components/page-components/ProfilePage/ProfilePage.tsx
@@ -135,13 +135,14 @@ export default function ProfilePage() {
                 if (data.event_time !== userInfo.event_time) {
                   const [selectedHour, selectedMinute] =
                     data.event_time.split(":")
-                  await sendToBackground({
+                  const { error } = await sendToBackground({
                     name: "updateEventAlarm",
                     body: {
                       eventHour: parseInt(selectedHour),
                       eventMinute: parseInt(selectedMinute)
                     }
                   })
+                  if (error) showBoundary(error)
                 }
 
                 setIsLoading(false)

--- a/src/components/page-components/ProfilePage/ProfilePage.tsx
+++ b/src/components/page-components/ProfilePage/ProfilePage.tsx
@@ -62,10 +62,11 @@ export default function ProfilePage() {
     if (!isPaused) {
       const [selectedHour, selectedMinute] =
         data.event_time.split(":")
-      await sendToBackground({
+      const { error } = await sendToBackground({
         name: "updateEventAlarm",
         body: { eventHour: selectedHour, eventMinute: selectedMinute }
       })
+      if (error) showBoundary(error)
     } else {
       await sendToBackground({ name: "removeEventAlarm" })
     }

--- a/src/utils/setEventAlarm.ts
+++ b/src/utils/setEventAlarm.ts
@@ -10,19 +10,24 @@ import eventAlarmListener from "./eventAlarmListener"
  * @param eventMinute
  * @description sets a unique alarm for our daily event. This function should be called every time the event_time value is updated to align the extensions behaviour with the state of our data.
  */
-export default function setEventAlarm(
+export default async function setEventAlarm(
   eventHour: number,
   eventMinute: number
 ) {
-  browser.alarms.clear("sequence-alarm")
-  browser.alarms.onAlarm.removeListener(eventAlarmListener)
+  await browser.alarms.clear("sequence-alarm")
+  await browser.alarms.onAlarm.removeListener(eventAlarmListener)
 
-  browser.alarms.create("sequence-alarm", {
+  await browser.alarms.create("sequence-alarm", {
     periodInMinutes: 1440,
     when: calculateCountDown(eventHour, eventMinute)
   })
-  browser.alarms.onAlarm.addListener(eventAlarmListener)
+  await browser.alarms.onAlarm.addListener(eventAlarmListener)
+  try {
+    const newAlarm = await browser.alarms.get("sequence-alarm")
 
-  const newAlarm = browser.alarms.get("sequence-alarm")
-  return newAlarm
+    return { data: newAlarm, error: null }
+  } catch (error) {
+    console.error(error)
+    return { data: null, error: error }
+  }
 }

--- a/src/utils/setEventAlarm.ts
+++ b/src/utils/setEventAlarm.ts
@@ -22,4 +22,7 @@ export default function setEventAlarm(
     when: calculateCountDown(eventHour, eventMinute)
   })
   browser.alarms.onAlarm.addListener(eventAlarmListener)
+
+  const newAlarm = browser.alarms.get("sequence-alarm")
+  return newAlarm
 }


### PR DESCRIPTION
# Description

**Closes #71**  

Fixes the frontend issue that was causing the user details form on `ProfilePage` to freeze whenever the user tried to edit the `event_time` value.

### Files changed

- `setEventAlarm.ts` - now returns the full object of the newly created alarm
- `messages/updateEventAlarm.ts` - checks for the return value of `setEventAlarm` and sends a response with the same shape as the response values in `fetchStrapiContent` - adding an error message if no alarm object has been set
- `ProfilePage.tsx` - handles the return value to `showBoundary` in case an error message is returned

### UI changes

n/a

### Changes to Documentation

n/a - this is just applying the same pattern we have everywhere else

# Tests

n/a - the same behaviour has been kept
