### PR TITLE
#62/fix update storage

### DIFF
--- a/src/__tests__/test-data/user-session-test-data.json
+++ b/src/__tests__/test-data/user-session-test-data.json
@@ -1,16 +1,7 @@
 {
   "jwt": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNzI4NDY4NTU1LCJleHAiOjE3MzEwNjA1NTV9.akf7EzGlTHSvaF2J5A4MWzYpWkwteyosQOjJolkll2I",
-  "user": {
-    "is_quiet": false,
-    "is_paused": false,
-    "project_id": 6,
-    "current_index": 0,
-    "birth_date": "10/12/1999",
-    "location": "London",
-    "event_time": "13:00:00.000",
-    "playlist": [],
-    "email": "userone@test.com",
-    "id": 1,
-    "username": "useOne"
-  }
+  "project_id": 6,
+  "current_index": 0,
+  "event_time": "13:00:00.000",
+  "id": 1
 }

--- a/src/__tests__/updateStorage.test.js
+++ b/src/__tests__/updateStorage.test.js
@@ -7,24 +7,18 @@ describe("updateStorage", () => {
   it("returns a new UserSession object updated for the provided keys", () => {
     const oldValue = userData
     const newValue = {
-      current_index: 5,
+      current_index: 0,
       project_id: 269,
-      username: "test name",
       jwt: "fake jwt"
     }
     const result = updateStorage(oldValue, newValue)
 
-    expect(result.user.event_time).toBe(
-      userData.user.event_time
-    )
-    expect(result.user.email).toBe(userData.user.email)
-    expect(result.user.is_quiet).toBe(
-      userData.user.is_quiet
-    )
+    expect(result.event_time).toBe(userData.event_time)
+    expect(result.email).toBe(userData.email)
+    expect(result.is_quiet).toBe(userData.is_quiet)
     expect(result.jwt).toBe("fake jwt")
-    expect(result.user.username).toBe("test name")
-    expect(result.user.current_index).toBe(5)
-    expect(result.user.project_id).toBe(269)
+    expect(result.current_index).toBe(0)
+    expect(result.project_id).toBe(269)
     expect(Object.keys(result).length).toBe(
       Object.keys(userData).length
     )


### PR DESCRIPTION
# Description

**Closes #62**  

Adjusted testing for `updateStorage` util following the types re-design for our data.

### Files changed

- `updateStorage.test.js` - removed assertions that checked for values no longer getting returned in the new type
- `test-data/user-session-test-data.json` - updated test data to match the new type of real-world data

### UI changes

n/a

### Changes to Documentation

n/a

# Tests

This is a testing PR. All changes described above.
