### PR TITLE
Stop pages from scrolling if the burger menu is open

### DIFF
--- a/src/components/BurgerMenu/BurgerMenu.css
+++ b/src/components/BurgerMenu/BurgerMenu.css
@@ -1,3 +1,7 @@
+*:has(.burger--logo__active) {
+  overflow: hidden;
+}
+
 .burger--heading {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
# Description

**Closes #57**  

Fixed the scrolling when the burger menu is open by targeting any component that is the parent to a class only applied to the burger menu when it is open. This css selector stops the parent component from scrolling.

### Files changed

- `BurgerMenu.css`

### UI changes

Looks the same on screengrabs but if you open the menu on a window that's longer than the height of the popup and then try to scroll you won't be able to, until you close the menu and the behaviour goes back to normal

### Changes to Documentation

n/a

# Tests

n/a - the behaviour is the same for all logic
