### PR TITLE
#75/pagination

### DIFF
--- a/src/background/messages/fetchAllProjects.ts
+++ b/src/background/messages/fetchAllProjects.ts
@@ -1,15 +1,21 @@
 import type { PlasmoMessaging } from "@plasmohq/messaging"
 
-import { allProjectQueryString } from "~queries/allProjectsQuery"
+import allProjectsQueryString from "~queries/allProjectsQuery"
 import type { ProjectData } from "~types/projectTypes"
 import { fetchStrapiContent } from "~utils/fetchStrapiContent"
 
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  const { page } = req.body
+
+  const newQueryString = allProjectsQueryString(page)
+
   const response = await fetchStrapiContent<
     Array<
       Omit<ProjectData, "content_creator" | "events" | "description">
     >
-  >(`api/projects?${allProjectQueryString}`)
+  >(`api/projects?${newQueryString}`)
+
+  console.log(response)
   res.send(response)
 }
 

--- a/src/background/messages/fetchAllProjects.ts
+++ b/src/background/messages/fetchAllProjects.ts
@@ -15,7 +15,6 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
     >
   >(`api/projects?${newQueryString}`)
 
-  console.log(response)
   res.send(response)
 }
 

--- a/src/background/messages/fetchListOfPopups.ts
+++ b/src/background/messages/fetchListOfPopups.ts
@@ -1,0 +1,24 @@
+import type { PlasmoMessaging } from "@plasmohq/messaging"
+
+import popupsListQuery from "~queries/popupsListQuery"
+import type { Favourite } from "~types/eventTypes"
+import { fetchStrapiContent } from "~utils/fetchStrapiContent"
+
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  const { page, popupArray } = req.body
+  console.log(popupArray)
+  const popupsQueryString = popupsListQuery(page, popupArray)
+
+  const response = await fetchStrapiContent<Favourite[]>(
+    `api/pop-ups?${popupsQueryString}`
+  )
+
+  if (response.error) {
+    console.error(response.error)
+    res.send(response)
+  }
+  console.log(response)
+  res.send(response)
+}
+
+export default handler

--- a/src/background/messages/fetchListOfPopups.ts
+++ b/src/background/messages/fetchListOfPopups.ts
@@ -6,7 +6,6 @@ import { fetchStrapiContent } from "~utils/fetchStrapiContent"
 
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   const { page, popupArray } = req.body
-  console.log(popupArray)
   const popupsQueryString = popupsListQuery(page, popupArray)
 
   const response = await fetchStrapiContent<Favourite[]>(
@@ -17,7 +16,7 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
     console.error(response.error)
     res.send(response)
   }
-  console.log(response)
+
   res.send(response)
 }
 

--- a/src/background/messages/viewSinglePopup.ts
+++ b/src/background/messages/viewSinglePopup.ts
@@ -5,7 +5,7 @@ import type { Popup } from "~types/eventTypes"
 import type { UserSession } from "~types/userTypes"
 import { fetchStrapiContent } from "~utils/fetchStrapiContent"
 import newStorage from "~utils/newStorage"
-import backgroundPopupCreate from "~utils/popup-utils/backgroundPopCreate"
+// import backgroundPopupCreate from "~utils/popup-utils/backgroundPopCreate"
 
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   const { id } = req.body
@@ -28,9 +28,9 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
 
   const temporaryPopup = response.data
   temporaryPopup.popup_position = "center"
-  await backgroundPopupCreate([temporaryPopup])
+  // await backgroundPopupCreate([temporaryPopup])
 
-  res.send(response)
+  res.send({ data: temporaryPopup, error: null })
 }
 
 export default handler

--- a/src/components/PaginationNav/PaginationNav.css
+++ b/src/components/PaginationNav/PaginationNav.css
@@ -4,4 +4,5 @@
   justify-content: space-evenly;
   align-items: center;
   margin-left: 50%;
+  margin-top: 10px;
 }

--- a/src/components/PaginationNav/PaginationNav.css
+++ b/src/components/PaginationNav/PaginationNav.css
@@ -1,6 +1,5 @@
 .pagination-nav {
   display: flex;
-  flex-direction: row;
   justify-content: space-evenly;
   align-items: center;
   margin-left: 50%;

--- a/src/components/PaginationNav/PaginationNav.css
+++ b/src/components/PaginationNav/PaginationNav.css
@@ -1,0 +1,7 @@
+.pagination-nav {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  align-items: center;
+  margin-left: 50%;
+}

--- a/src/components/PaginationNav/PaginationNav.tsx
+++ b/src/components/PaginationNav/PaginationNav.tsx
@@ -1,21 +1,29 @@
+import type { Dispatch, SetStateAction } from "react"
+
 import "./PaginationNav.css"
 
 export default function PaginationNav({
   pageNumber,
   pageCount,
-  incrementPage,
-  decrementPage
+  setterFunction
 }: {
   pageNumber: number
   pageCount: number
-  incrementPage: () => void
-  decrementPage: () => void
+  setterFunction: Dispatch<SetStateAction<number>>
 }) {
+  const navigateToNext = () => {
+    setterFunction(pageNumber + 1)
+  }
+
+  const navigateToPrevious = () => {
+    setterFunction(pageNumber - 1)
+  }
+
   return (
     <div className="pagination-nav">
       <button
         className="button--secondary"
-        onClick={decrementPage}
+        onClick={navigateToPrevious}
         disabled={pageNumber === 1}
       >
         previous
@@ -23,7 +31,7 @@ export default function PaginationNav({
       <p className="bold">{`${pageNumber} of ${pageCount}`}</p>
       <button
         className="button--secondary"
-        onClick={incrementPage}
+        onClick={navigateToNext}
         disabled={pageNumber === pageCount}
       >
         next

--- a/src/components/PaginationNav/PaginationNav.tsx
+++ b/src/components/PaginationNav/PaginationNav.tsx
@@ -1,3 +1,5 @@
+import "./PaginationNav.css"
+
 export default function PaginationNav({
   pageNumber,
   pageCount,
@@ -10,7 +12,7 @@ export default function PaginationNav({
   decrementPage: () => void
 }) {
   return (
-    <div>
+    <div className="pagination-nav">
       <button
         className="button--secondary"
         onClick={decrementPage}

--- a/src/components/PaginationNav/PaginationNav.tsx
+++ b/src/components/PaginationNav/PaginationNav.tsx
@@ -1,0 +1,31 @@
+export default function PaginationNav({
+  pageNumber,
+  pageCount,
+  incrementPage,
+  decrementPage
+}: {
+  pageNumber: number
+  pageCount: number
+  incrementPage: () => void
+  decrementPage: () => void
+}) {
+  return (
+    <div>
+      <button
+        className="button--secondary"
+        onClick={decrementPage}
+        disabled={pageNumber === 1}
+      >
+        previous
+      </button>
+      <p className="bold">{`${pageNumber} of ${pageCount}`}</p>
+      <button
+        className="button--secondary"
+        onClick={incrementPage}
+        disabled={pageNumber === pageCount}
+      >
+        next
+      </button>
+    </div>
+  )
+}

--- a/src/components/PopupCard/PopupCard.css
+++ b/src/components/PopupCard/PopupCard.css
@@ -3,6 +3,7 @@
   width: 165px;
   position: relative;
   cursor: pointer;
+  border-radius: 7px;
 }
 
 .popup-card__editing {

--- a/src/components/PopupCard/PopupCard.css
+++ b/src/components/PopupCard/PopupCard.css
@@ -19,6 +19,7 @@
   position: absolute;
   top: 0;
   left: 0;
+  border: 2px solid var(--highlight);
 }
 
 .popup-card--remove-button {

--- a/src/components/PopupCard/PopupCard.tsx
+++ b/src/components/PopupCard/PopupCard.tsx
@@ -8,6 +8,8 @@ import { useErrorBoundary } from "react-error-boundary"
 
 import { sendToBackground } from "@plasmohq/messaging"
 
+import displayPopup from "~utils/popup-utils/displayPopup"
+
 export default function PopupCard({
   popup,
   isEditing,
@@ -32,7 +34,7 @@ export default function PopupCard({
   const handlePopup = async () => {
     if (isEditing) return
 
-    const { error } = await sendToBackground({
+    const { data, error } = await sendToBackground({
       name: "viewSinglePopup",
       body: { id: popup.id }
     })
@@ -41,6 +43,8 @@ export default function PopupCard({
       return showBoundary(
         "Something went wrong. Please try again later."
       )
+
+    await displayPopup(data)
   }
 
   return (

--- a/src/components/PopupCard/PopupCard.tsx
+++ b/src/components/PopupCard/PopupCard.tsx
@@ -46,7 +46,7 @@ export default function PopupCard({
   return (
     <button onClick={handlePopup}>
       <div
-        className={`${isEditing ? "popup-card__editing" : ""} popup-card content-box shadow`}
+        className={`${isEditing ? "popup-card__editing" : ""} popup-card shadow`}
       >
         <img
           className="popup-card--image"

--- a/src/components/ProjectCards/ProjectCard.css
+++ b/src/components/ProjectCards/ProjectCard.css
@@ -8,6 +8,7 @@
   height: 165px;
   border-radius: 0.438rem;
   object-fit: cover;
+  border: 2px solid var(--highlight);
 }
 
 .project-card img:hover {
@@ -17,5 +18,5 @@
 
 .project-card span {
   font-weight: 300;
-  font-size: .65rem;
+  font-size: 0.65rem;
 }

--- a/src/components/page-components/ExplorePage/ExplorePage.tsx
+++ b/src/components/page-components/ExplorePage/ExplorePage.tsx
@@ -11,6 +11,7 @@ import FilterTags from "~components/FilterTags/FilterTags"
 import Footer from "~components/Footer/Footer"
 import PaginationNav from "~components/PaginationNav/PaginationNav"
 import ProjectCard from "~components/ProjectCards/ProjectCard"
+import type { Meta } from "~types/baseTypes"
 import type { ProjectData } from "~types/projectTypes"
 
 export default function ExplorePage() {
@@ -21,12 +22,18 @@ export default function ExplorePage() {
 
   useEffect(() => {
     const fetchAllProjects = async () => {
-      const { data, error, meta } = await sendToBackground({
-        name: "fetchAllProjects",
-        body: { page: pageNumber }
-      })
+      const {
+        data,
+        error,
+        meta
+      }: { data: ProjectData[]; error: string | null; meta: Meta } =
+        await sendToBackground({
+          name: "fetchAllProjects",
+          body: { page: pageNumber }
+        })
 
       if (error) showBoundary(error)
+        
       setPageCount(meta.pagination.pageCount)
       setProjects(data)
     }

--- a/src/components/page-components/ExplorePage/ExplorePage.tsx
+++ b/src/components/page-components/ExplorePage/ExplorePage.tsx
@@ -33,20 +33,12 @@ export default function ExplorePage() {
         })
 
       if (error) showBoundary(error)
-        
+
       setPageCount(meta.pagination.pageCount)
       setProjects(data)
     }
     fetchAllProjects()
   }, [pageNumber])
-
-  const navigateToNext = () => {
-    setPageNumber(page => page + 1)
-  }
-
-  const navigateToPrevious = () => {
-    setPageNumber(page => page - 1)
-  }
 
   return (
     <div className="explore-page page">
@@ -65,8 +57,7 @@ export default function ExplorePage() {
           <PaginationNav
             pageNumber={pageNumber}
             pageCount={pageCount}
-            incrementPage={navigateToNext}
-            decrementPage={navigateToPrevious}
+            setterFunction={setPageNumber}
           />
         </div>
       </main>

--- a/src/components/page-components/ExplorePage/ExplorePage.tsx
+++ b/src/components/page-components/ExplorePage/ExplorePage.tsx
@@ -55,14 +55,14 @@ export default function ExplorePage() {
               ))}
             </div>
           )}
+          <PaginationNav
+            pageNumber={pageNumber}
+            pageCount={pageCount}
+            incrementPage={navigateToNext}
+            decrementPage={navigateToPrevious}
+          />
         </div>
       </main>
-      <PaginationNav
-        pageNumber={pageNumber}
-        pageCount={pageCount}
-        incrementPage={navigateToNext}
-        decrementPage={navigateToPrevious}
-      />
       <Footer />
     </div>
   )

--- a/src/components/page-components/ExplorePage/ExplorePage.tsx
+++ b/src/components/page-components/ExplorePage/ExplorePage.tsx
@@ -10,24 +10,27 @@ import BurgerMenu from "~components/BurgerMenu/BurgerMenu"
 import FilterTags from "~components/FilterTags/FilterTags"
 import Footer from "~components/Footer/Footer"
 import ProjectCard from "~components/ProjectCards/ProjectCard"
-import type { AllProjectResponse } from "~types/projectTypes"
+import type { ProjectData } from "~types/projectTypes"
 
 export default function ExplorePage() {
-  const [projects, setProjects] =
-    useState<AllProjectResponse["data"]>()
+  const [projects, setProjects] = useState<ProjectData[]>()
+  const [pageNumber, setPageNumber] = useState<number>(1)
+  const [pageCount, setPageCount] = useState<number>(1)
   const { showBoundary } = useErrorBoundary()
 
   useEffect(() => {
     const fetchAllProjects = async () => {
-      const { data, error } = await sendToBackground({
-        name: "fetchAllProjects"
+      const { data, error, meta } = await sendToBackground({
+        name: "fetchAllProjects",
+        body: { page: pageNumber }
       })
 
       if (error) showBoundary(error)
+      setPageCount(meta.pagination.pageCount)
       setProjects(data)
     }
     fetchAllProjects()
-  }, [])
+  }, [pageNumber])
 
   return (
     <div className="explore-page page">
@@ -45,6 +48,23 @@ export default function ExplorePage() {
           )}
         </div>
       </main>
+      <div>
+        <button
+          className="button--secondary"
+          onClick={() => setPageNumber(page => page - 1)}
+          disabled={pageNumber === 1}
+        >
+          previous
+        </button>
+        <p className="bold">{pageNumber}</p>
+        <button
+          className="button--secondary"
+          onClick={() => setPageNumber(page => page + 1)}
+          disabled={pageNumber === pageCount}
+        >
+          next
+        </button>
+      </div>
       <Footer />
     </div>
   )

--- a/src/components/page-components/ExplorePage/ExplorePage.tsx
+++ b/src/components/page-components/ExplorePage/ExplorePage.tsx
@@ -9,6 +9,7 @@ import { sendToBackground } from "@plasmohq/messaging"
 import BurgerMenu from "~components/BurgerMenu/BurgerMenu"
 import FilterTags from "~components/FilterTags/FilterTags"
 import Footer from "~components/Footer/Footer"
+import PaginationNav from "~components/PaginationNav/PaginationNav"
 import ProjectCard from "~components/ProjectCards/ProjectCard"
 import type { ProjectData } from "~types/projectTypes"
 
@@ -32,6 +33,14 @@ export default function ExplorePage() {
     fetchAllProjects()
   }, [pageNumber])
 
+  const navigateToNext = () => {
+    setPageNumber(page => page + 1)
+  }
+
+  const navigateToPrevious = () => {
+    setPageNumber(page => page - 1)
+  }
+
   return (
     <div className="explore-page page">
       <BurgerMenu />
@@ -48,23 +57,12 @@ export default function ExplorePage() {
           )}
         </div>
       </main>
-      <div>
-        <button
-          className="button--secondary"
-          onClick={() => setPageNumber(page => page - 1)}
-          disabled={pageNumber === 1}
-        >
-          previous
-        </button>
-        <p className="bold">{pageNumber}</p>
-        <button
-          className="button--secondary"
-          onClick={() => setPageNumber(page => page + 1)}
-          disabled={pageNumber === pageCount}
-        >
-          next
-        </button>
-      </div>
+      <PaginationNav
+        pageNumber={pageNumber}
+        pageCount={pageCount}
+        incrementPage={navigateToNext}
+        decrementPage={navigateToPrevious}
+      />
       <Footer />
     </div>
   )

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -8,8 +8,10 @@ import { sendToBackground } from "@plasmohq/messaging"
 
 import BurgerMenu from "~components/BurgerMenu/BurgerMenu"
 import Footer from "~components/Footer/Footer"
+import PaginationNav from "~components/PaginationNav/PaginationNav"
 import PopupCard from "~components/PopupCard/PopupCard"
 import ToggleSwitch from "~components/ToggleSwitch/ToggleSwitch"
+import { Meta } from "~types/baseTypes"
 import type { Favourite } from "~types/eventTypes"
 import type { UserFavourites, UserSession } from "~types/userTypes"
 import newStorage from "~utils/newStorage"
@@ -20,6 +22,8 @@ export default function FavouritesPage() {
   const [favouritesList, setFavouritesList] = useState<
     Array<Favourite>
   >([])
+  const [pageNumber, setPageNumber] = useState<number>(1)
+  const [pageCount, setPageCount] = useState<number>(1)
   const storage = newStorage()
 
   const handleToggleSwitch = () => {
@@ -49,25 +53,60 @@ export default function FavouritesPage() {
       )
 
       const {
-        data,
-        error
+        data: favouritesData,
+        error: favouritesError
       }: {
         data: UserFavourites
         error: string | null
       } = await sendToBackground({
         name: "fetchUserFavourites",
-        body: { jwt: userSession.jwt, id: userSession.id }
+        body: {
+          jwt: userSession.jwt,
+          id: userSession.id
+        }
       })
-      if (error)
+
+      if (favouritesError)
         return showBoundary(
           "Something went wrong. Please try again later."
         )
 
-      setFavouritesList(data.favourites)
+      // FETCH POPUPS IN THIS ARRAY
+
+      const {
+        data: popupData,
+        error: popupError,
+        meta
+      }: {
+        data: Favourite[]
+        error: string | null
+        meta: Meta
+      } = await sendToBackground({
+        name: "fetchListOfPopups",
+        body: {
+          page: pageNumber,
+          popupArray: favouritesData.favourites.map(
+            favourite => favourite.id
+          )
+        }
+      })
+
+      if (popupError) return showBoundary(popupError)
+
+      setPageCount(meta.pagination.pageCount)
+      setFavouritesList(popupData)
     }
 
     getFavourites()
-  }, [setFavouritesList])
+  }, [setFavouritesList, pageNumber])
+
+  const navigateToNext = () => {
+    setPageNumber(page => page + 1)
+  }
+
+  const navigateToPrevious = () => {
+    setPageNumber(page => page - 1)
+  }
 
   return (
     <div className="page favourites-page">
@@ -100,6 +139,12 @@ export default function FavouritesPage() {
           </div>
         )}
       </main>
+      <PaginationNav
+        pageNumber={pageNumber}
+        pageCount={pageCount}
+        incrementPage={navigateToNext}
+        decrementPage={navigateToPrevious}
+      />
       <Footer />
     </div>
   )

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -71,6 +71,9 @@ export default function FavouritesPage() {
           "Something went wrong. Please try again later."
         )
 
+      const targetArray: number[] = favouritesData.favourites.map(
+        favourite => favourite.id
+      )
       const {
         data: popupData,
         error: popupError,
@@ -83,9 +86,7 @@ export default function FavouritesPage() {
         name: "fetchListOfPopups",
         body: {
           page: pageNumber,
-          popupArray: favouritesData.favourites.map(
-            favourite => favourite.id
-          )
+          popupArray: targetArray
         }
       })
 

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -99,14 +99,6 @@ export default function FavouritesPage() {
     getFavourites()
   }, [setFavouritesList, pageNumber])
 
-  const navigateToNext = () => {
-    setPageNumber(page => page + 1)
-  }
-
-  const navigateToPrevious = () => {
-    setPageNumber(page => page - 1)
-  }
-
   return (
     <div className="page favourites-page">
       <BurgerMenu />
@@ -141,8 +133,7 @@ export default function FavouritesPage() {
       <PaginationNav
         pageNumber={pageNumber}
         pageCount={pageCount}
-        incrementPage={navigateToNext}
-        decrementPage={navigateToPrevious}
+        setterFunction={setPageNumber}
       />
       <Footer />
     </div>

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -71,8 +71,6 @@ export default function FavouritesPage() {
           "Something went wrong. Please try again later."
         )
 
-      // FETCH POPUPS IN THIS ARRAY
-
       const {
         data: popupData,
         error: popupError,

--- a/src/queries/allProjectsQuery.ts
+++ b/src/queries/allProjectsQuery.ts
@@ -10,7 +10,7 @@ export default function allProjectsQueryString(pageNumber: number) {
     },
     pagination: {
       page: pageNumber,
-      pageSize: 1
+      pageSize: 6
     }
   }
 

--- a/src/queries/allProjectsQuery.ts
+++ b/src/queries/allProjectsQuery.ts
@@ -1,14 +1,22 @@
 import qs from "qs"
 
-const allProjectsQuery = {
-  fields: ["id", "title", "launch_date"],
-  populate: {
-    cover_image: {
-      fields: ["*"]
+export default function allProjectsQueryString(pageNumber: number) {
+  const allProjectsQuery = {
+    fields: ["id", "title", "launch_date"],
+    populate: {
+      cover_image: {
+        fields: ["*"]
+      }
+    },
+    pagination: {
+      page: pageNumber,
+      pageSize: 1
     }
   }
-}
 
-export const allProjectQueryString = qs.stringify(allProjectsQuery, {
-  encodeValuesOnly: true
-})
+  const allProjectQueryString = qs.stringify(allProjectsQuery, {
+    encodeValuesOnly: true
+  })
+
+  return allProjectQueryString
+}

--- a/src/queries/popupsListQuery.ts
+++ b/src/queries/popupsListQuery.ts
@@ -1,0 +1,38 @@
+import qs from "qs"
+
+export default function popupsListQuery(
+  pageNumber: number,
+  targetIds: Array<number>
+) {
+  const popupsQuery = {
+    fields: ["*"],
+    populate: {
+      thumbnail_image: {
+        populate: {
+          formats: {
+            populate: {
+              thumbnail: {
+                fields: ["url"]
+              }
+            }
+          }
+        }
+      }
+    },
+    pagination: {
+      page: pageNumber,
+      pageSize: 6
+    },
+    filters: {
+      id: {
+        $in: targetIds
+      }
+    }
+  }
+
+  const popupsListQuery = qs.stringify(popupsQuery, {
+    encodedValuesOnly: true
+  })
+
+  return popupsListQuery
+}

--- a/src/queries/userFavouritesQuery.ts
+++ b/src/queries/userFavouritesQuery.ts
@@ -4,25 +4,14 @@ const favouritesQuery = {
   fields: ["id"],
   populate: {
     favourites: {
-      fields: ["id, work_title"],
-      populate: {
-        thumbnail_image: {
-          populate: {
-            formats: {
-              populate: {
-                thumbnail: {
-                  fields: ["url"]
-                }
-              }
-            }
-          }
-        }
-      }
+      fields: ["id"]
     }
   }
 }
 
 export const userFavouritesQueryString = qs.stringify(
   favouritesQuery,
-  { encodedValuesOnly: true }
+  {
+    encodedValuesOnly: true
+  }
 )

--- a/src/types/baseTypes.ts
+++ b/src/types/baseTypes.ts
@@ -1,0 +1,8 @@
+export interface Meta {
+  pagination: {
+    page: number
+    pageCount: number
+    pageSize: number
+    total: number
+  }
+}

--- a/src/utils/popup-utils/displayPopup.ts
+++ b/src/utils/popup-utils/displayPopup.ts
@@ -1,0 +1,130 @@
+import Browser from "webextension-polyfill"
+
+import { MediaContent, Popup, SlimPopup } from "~types/eventTypes"
+
+import calculatePopupCoordinates from "./calculatePopupCoordinates"
+import createWindow from "./createWindow"
+import determineFormat from "./determineFormat"
+import parseImageSize from "./parseImageSize"
+import parseWindowSize from "./parseWindowSize"
+
+export default async function displayPopup(popup: Popup) {
+  const screenHeight = window.screen.height
+  const screenWidth = window.screen.width
+
+  let slimPopup: SlimPopup
+
+  if (popup.popup_content[0].__component === "piece.text-content") {
+    const { width, height } = parseWindowSize(
+      popup.popup_size,
+      screenWidth
+    )
+
+    const { top, left } = calculatePopupCoordinates(
+      popup,
+      screenHeight,
+      screenWidth,
+      width,
+      height
+    )
+
+    slimPopup = {
+      type: "text",
+      index: 0,
+      popupInfo: {
+        artist_name: popup.artist_name,
+        medium: popup.medium,
+        work_title: popup.work_title,
+        creation_date: popup.creation_date,
+        external_link: popup.external_link
+      },
+      description: popup.popup_content[0].description,
+      text_content: popup.popup_content[0].text_content,
+      width: width,
+      height: height,
+      top: top,
+      left: left
+    }
+  }
+
+  if (popup.popup_content[0].__component === "piece.piece") {
+    switch (determineFormat(popup.popup_content[0].media.ext)) {
+      case "image": {
+        const { height, width, url } = parseImageSize(
+          popup.popup_size,
+          popup.popup_content as unknown as MediaContent
+        )
+        const { top, left } = calculatePopupCoordinates(
+          popup,
+          screenHeight,
+          screenWidth,
+          width,
+          height
+        )
+
+        slimPopup = {
+          type: "image",
+          index: 0,
+          popupInfo: {
+            artist_name: popup.artist_name,
+            medium: popup.medium,
+            work_title: popup.work_title,
+            creation_date: popup.creation_date,
+            external_link: popup.external_link
+          },
+          url: url,
+          description: popup.popup_content[0].description,
+          width: width,
+          height: height,
+          top: top,
+          left: left
+        }
+        break
+      }
+      case "video": {
+        const { width, height } = parseWindowSize(
+          popup.popup_size,
+          screenWidth
+        )
+        const { top, left } = calculatePopupCoordinates(
+          popup,
+          screenHeight,
+          screenWidth,
+          width,
+          height
+        )
+
+        slimPopup = {
+          type: "video",
+          index: 0,
+          popupInfo: {
+            artist_name: popup.artist_name,
+            medium: popup.medium,
+            work_title: popup.work_title,
+            creation_date: popup.creation_date,
+            external_link: popup.external_link
+          },
+          url: popup.popup_content[0].media.url,
+          description: popup.popup_content[0].description,
+          width: width,
+          height: height,
+          top: top,
+          left: left
+        }
+        break
+      }
+      default:
+        console.error("Nor format found")
+    }
+  }
+
+  await Browser.storage.session.set({ arebytePopups: [slimPopup] })
+
+  await createWindow(
+    slimPopup.index,
+    slimPopup.width,
+    slimPopup.height,
+    slimPopup.top,
+    slimPopup.left
+  )
+}

--- a/src/utils/popup-utils/displayPopup.ts
+++ b/src/utils/popup-utils/displayPopup.ts
@@ -66,6 +66,7 @@ export default async function displayPopup(popup: Popup) {
           type: "image",
           index: 0,
           popupInfo: {
+            id: popup.id,
             artist_name: popup.artist_name,
             medium: popup.medium,
             work_title: popup.work_title,


### PR DESCRIPTION
# Description

**Closes #75**  

Sets pagination for the Explore and Favourites page.

This pr refactors some of our query strings and message handlers to receive a `pageNumber` argument to fetch a specific page for the GET call made. This is connected to the frontend with a new component that's been imported to both page components.

Depending on what we decided on the next design review we can change the look of that component in a single place.

### Files changed

- `components/PaginationNav/**` - new component to control the fetching of a new page in the fetch call
- `ExplorePage.tsx` && `FavouritesPage.tsx` - imported the new component and refactored the logic around the fetch of data in the useEffect to handle pagination
- `components/PopupCard/` && `components/ProjectCard` - both components needed a border to match the figma design, so that was added to the image element tag in both
-   `types/baseTypes.ts` - declared a `Meta` interface to allow us to handle the metadata returned from fetch calls that include pagination
- `allProjectsQuery.ts` - now returns a function that creates the query string to include pagination and request the page number passed to it as an argument
- `messages/fetchListOfPopups.ts` && `popupsListQuery.ts` - new message handler that fetches a list of popups based on an array of popup ids && query string dynamically created to return the requested page of the api call

### UI changes

<img width="374" alt="Screenshot 2024-10-29 at 09 31 29" src="https://github.com/user-attachments/assets/bc7c9535-fddc-47a2-8475-db605b85d44e">
<img width="372" alt="Screenshot 2024-10-29 at 09 32 05" src="https://github.com/user-attachments/assets/50068206-50ab-458a-a517-51f9264ed85e">


### Changes to Documentation

n/a

# Tests

no new tests -  the existing tests check the return of the same message handlers, we are only isolating a number of items to return at each time
