### PR TITLE
#80/fix iterate index

### DIFF
--- a/src/__tests__/iterateIndex.test.js
+++ b/src/__tests__/iterateIndex.test.js
@@ -5,20 +5,20 @@ import eventData from "./test-data/event-test-data.json"
 
 describe("iterateIndex", () => {
   it("returns the given array incremented by one", () => {
-    const popupsArray = eventData.data.pop_ups
+    const totalPopups = eventData.data.pop_ups.length
 
-    const result = iterateIndex(popupsArray, 0)
-    const secondResult = iterateIndex(popupsArray, 2)
+    const result = iterateIndex(totalPopups, 0)
+    const secondResult = iterateIndex(totalPopups, 2)
 
     expect(result).toBe(1)
     expect(secondResult).toBe(3)
   })
 
   it("returns 0 if the current index is the last in the array", () => {
-    const popupsArray = eventData.data.pop_ups
-    const currentIndex = popupsArray.length
+    const totalPopups = eventData.data.pop_ups.length
+    const currentIndex = totalPopups
 
-    const result = iterateIndex(popupsArray, currentIndex)
+    const result = iterateIndex(totalPopups, currentIndex)
 
     expect(result).toBe(0)
   })

--- a/src/__tests__/updateStorage.test.js
+++ b/src/__tests__/updateStorage.test.js
@@ -7,8 +7,8 @@ describe("updateStorage", () => {
   it("returns a new UserSession object updated for the provided keys", () => {
     const oldValue = userData
     const newValue = {
-      current_index: 0,
-      project_id: 269,
+      current_index: 269,
+      project_id: 0,
       jwt: "fake jwt"
     }
     const result = updateStorage(oldValue, newValue)
@@ -17,8 +17,8 @@ describe("updateStorage", () => {
     expect(result.email).toBe(userData.email)
     expect(result.is_quiet).toBe(userData.is_quiet)
     expect(result.jwt).toBe("fake jwt")
-    expect(result.current_index).toBe(0)
-    expect(result.project_id).toBe(269)
+    expect(result.current_index).toBe(269)
+    expect(result.project_id).toBe(0)
     expect(Object.keys(result).length).toBe(
       Object.keys(userData).length
     )

--- a/src/background/messages/manuallyTriggerEventAlarm.ts
+++ b/src/background/messages/manuallyTriggerEventAlarm.ts
@@ -1,0 +1,15 @@
+import Browser from "webextension-polyfill"
+
+import type { PlasmoMessaging } from "@plasmohq/messaging"
+
+import eventAlarmListener from "~utils/eventAlarmListener"
+
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  const alarm = await Browser.alarms.get("sequence-alarm")
+  console.log(alarm)
+  await eventAlarmListener(alarm)
+
+  res.send("ok")
+}
+
+export default handler

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -5,10 +5,7 @@ import "./Footer.css"
 const Footer = () => {
   const triggerPopups = async () => {
     await sendToBackground({
-      name: "triggerPopup",
-      body: {
-        id: 5
-      }
+      name: "manuallyTriggerEventAlarm"
     })
   }
 

--- a/src/utils/eventAlarmListener.ts
+++ b/src/utils/eventAlarmListener.ts
@@ -1,10 +1,10 @@
 import type { UserSession } from "~types/userTypes"
 
-import backgroundPopupCreate from "./popup-utils/backgroundPopCreate"
 import getCurrentProjectPopups from "./getCurrentProjectPopups"
 import getProjectPopups from "./getProjectPopups"
 import iterateIndex from "./iterateIndex"
 import newStorage from "./newStorage"
+import backgroundPopupCreate from "./popup-utils/backgroundPopCreate"
 import updateStorage from "./updateStorage"
 
 export default async function eventAlarmListener(alarm) {
@@ -18,28 +18,30 @@ export default async function eventAlarmListener(alarm) {
     const projectId = userSession.project_id
     const currentIndex = userSession.current_index
 
-    const pop_ups =
+    const { pop_ups, numberOfEvents } =
       projectId === 0
         ? await getCurrentProjectPopups(currentIndex)
         : await getProjectPopups(projectId, currentIndex)
 
+    console.log(pop_ups)
     await backgroundPopupCreate(pop_ups)
-    const newIndex = iterateIndex(pop_ups, currentIndex)
-
+    const newIndex = iterateIndex(numberOfEvents, currentIndex)
     const updatedSession = updateStorage(userSession, {
       current_index: newIndex,
       ...(newIndex === 0 && { project_id: 0 })
     })
+    console.log(updatedSession)
     await storage.set("arebyte-audience-session", updatedSession)
   } else {
     const publicIndex: number = await storage.get(
       "arebyte-public-index"
     )
 
-    const pop_ups = await getCurrentProjectPopups(publicIndex)
+    const { pop_ups, numberOfEvents } =
+      await getCurrentProjectPopups(publicIndex)
     await backgroundPopupCreate(pop_ups)
 
-    const newPublicIndex = iterateIndex(pop_ups, publicIndex)
+    const newPublicIndex = iterateIndex(numberOfEvents, publicIndex)
     await storage.set("arebyte-public-index", newPublicIndex)
   }
 }

--- a/src/utils/eventAlarmListener.ts
+++ b/src/utils/eventAlarmListener.ts
@@ -23,14 +23,12 @@ export default async function eventAlarmListener(alarm) {
         ? await getCurrentProjectPopups(currentIndex)
         : await getProjectPopups(projectId, currentIndex)
 
-    console.log(pop_ups)
     await backgroundPopupCreate(pop_ups)
     const newIndex = iterateIndex(numberOfEvents, currentIndex)
     const updatedSession = updateStorage(userSession, {
       current_index: newIndex,
       ...(newIndex === 0 && { project_id: 0 })
     })
-    console.log(updatedSession)
     await storage.set("arebyte-audience-session", updatedSession)
   } else {
     const publicIndex: number = await storage.get(

--- a/src/utils/getCurrentProjectPopups.ts
+++ b/src/utils/getCurrentProjectPopups.ts
@@ -22,5 +22,8 @@ export default async function getCurrentProjectPopups(
   } = await fetchStrapiContent<EventData>(
     `api/events/${currentEventId}?${eventPopupQueryString}`
   )
-  return pop_ups
+  return {
+    pop_ups: pop_ups,
+    numberOfEvents: currentProject.data.project.events.length
+  }
 }

--- a/src/utils/getProjectPopups.ts
+++ b/src/utils/getProjectPopups.ts
@@ -1,27 +1,30 @@
 import { eventPopupQueryString } from "~queries/eventPopupsQuery"
 import { projectQueryString } from "~queries/projectQuery"
-import type { EventResponse } from "~types/eventTypes"
-import type { ProjectResponse } from "~types/projectTypes"
+import type { EventData } from "~types/eventTypes"
+import type { ProjectData } from "~types/projectTypes"
 
 import { fetchStrapiContent } from "./fetchStrapiContent"
 
 /**
- * 
+ *
  * @description fetches an array of popups from the project with the given Id
  */
 export default async function getProjectPopups(
   projectId: number,
   currentIndex: number
 ) {
-  const currentProject = await fetchStrapiContent<ProjectResponse>(
+  const currentProject = await fetchStrapiContent<ProjectData>(
     `api/projects/${projectId}?${projectQueryString}`
   )
   const currentEventId = currentProject.data.events[currentIndex].id
   const {
     data: { pop_ups }
-  } = await fetchStrapiContent<EventResponse>(
+  } = await fetchStrapiContent<EventData>(
     `api/events/${currentEventId}?${eventPopupQueryString}`
   )
 
-  return pop_ups
+  return {
+    pop_ups: pop_ups,
+    numberOfEvents: currentProject.data.events.length
+  }
 }

--- a/src/utils/iterateIndex.ts
+++ b/src/utils/iterateIndex.ts
@@ -1,17 +1,15 @@
-import { Popup } from "~types/eventTypes"
-
 /**
  *
- * @param givenArray full array of pop_ups in an event
+ * @param totalCount expects the length of the event array in the target object
  * @param currentIndex current_index in storage
  * @returns the next index in the array or zero if the full length of the array has been reached
  */
 export default function iterateIndex(
-  givenArray: Array<Popup>,
+  totalCount: number,
   currentIndex: number
 ): number {
-  const fullLength = givenArray.length
-  if (currentIndex >= fullLength) return 0
+  if (currentIndex === totalCount - 1 || currentIndex === totalCount)
+    return 0
 
   return currentIndex + 1
 }

--- a/src/utils/updateStorage.ts
+++ b/src/utils/updateStorage.ts
@@ -22,6 +22,7 @@ export default function updateStorage(
   const currentKey = Object.keys(currentValue)[index]
   switch (true) {
     case !newValue[currentKey] &&
+      newValue[currentKey] !== 0 &&
       typeof currentValue[currentKey] !== "object":
       changes = {
         ...changes,


### PR DESCRIPTION
# Description

**Closes #80**

A series of fun mistakes were working up to this error: 

- `updateStorage.ts` was evaluating a new value of `0` as `nullish` and passing the old value to the new storage object
- `updateStorage.test.js` was checking a change into `0` as one of it's scenarios but the test data already was set to `0` from the start, giving us a false positive
- and finally we were passing the wrong array to `iterateIndex`. We were evaluating against the total array of popups instead of the total array of events 🤦 

### Files changed

- `updateStorage.ts` - refactor to consider value of `0` as non-nullish
- `iterateIndex.ts` - now takes two numbers instead of a number and an array
- `getCurrentProjectPopups.ts` and `getProjectPopups.ts` - now return an object that includes the total number of events in that project as well as the full array of popups in the current event
- `setEventAlarm.ts` - implements the changes above to it's function calls 
- `messages/manuallyTriggerEventAlarm.ts` && `Footer.tsx` - implement a manual trigger of the event alarm for manual integration testing of our sequence triggers

### UI changes

n/a

### Changes to Documentation

n/a

# Tests

- `updateStorage.test.js` - now considers a different value being changed to 0 and the value that is 0 in the test data changes to a higher number
- `iterateIndex.test.js` - was adjusted to take a second number instead of an index to reflect the same behaviour as before while calling the refactored version of the function
