### PR TITLE
#45/about page

### DIFF
--- a/src/background/messages/fetchAboutContent.ts
+++ b/src/background/messages/fetchAboutContent.ts
@@ -1,0 +1,18 @@
+import type { PlasmoMessaging } from "@plasmohq/messaging"
+
+import type { AboutPage } from "~types/baseTypes"
+import { fetchStrapiContent } from "~utils/fetchStrapiContent"
+
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  const response =
+    await fetchStrapiContent<AboutPage>(`api/about-page`)
+
+  if (response.error) {
+    console.error(response.error)
+    res.send(response)
+  }
+
+  res.send(response)
+}
+
+export default handler

--- a/src/components/BurgerMenu/BurgerMenu.tsx
+++ b/src/components/BurgerMenu/BurgerMenu.tsx
@@ -133,7 +133,12 @@ export default function BurgerMenu() {
             </a>
           </div>
           <div>
-            <button className="button--secondary bold">ABOUT</button>
+            <button
+              className="button--secondary bold"
+              onClick={() => navigateTo("about")}
+            >
+              ABOUT
+            </button>
             <button className="button--secondary bold">
               CONTACT
             </button>

--- a/src/components/page-components/AboutPage/AboutPage.css
+++ b/src/components/page-components/AboutPage/AboutPage.css
@@ -1,0 +1,29 @@
+.about-page {
+  animation-name: slideRight;
+  background-color: var(--base);
+  padding-top: 20px;
+}
+
+.about-page--content {
+  grid-column: 1/3;
+}
+
+.about-page--credits {
+  grid-column: 1/3;
+}
+
+.about-page-enter {
+  z-index: 3;
+}
+
+.about-page-enter-active {
+  z-index: 3;
+}
+
+.about-page-exit {
+  z-index: 1;
+}
+
+.about-page-exit-active {
+  z-index: 1;
+}

--- a/src/components/page-components/AboutPage/AboutPage.tsx
+++ b/src/components/page-components/AboutPage/AboutPage.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react"
+import { useErrorBoundary } from "react-error-boundary"
+
+import { sendToBackground } from "@plasmohq/messaging"
+
+import type { AboutPage } from "~types/baseTypes"
+
+export default function AboutPage() {
+  const [content, setContent] = useState("")
+  const { showBoundary } = useErrorBoundary()
+
+  useEffect(() => {
+    const getContent = async () => {
+      const {
+        data,
+        error
+      }: { data: AboutPage; error: string | null } =
+        await sendToBackground({
+          name: "fetchAboutContent"
+        })
+
+      if (error) return showBoundary(error)
+
+      setContent(data.abstract)
+    }
+
+    getContent()
+  }, [])
+
+  return (
+    <>
+      <h1>ABOUT</h1>
+      {content && <p>{content}</p>}
+    </>
+  )
+}

--- a/src/components/page-components/AboutPage/AboutPage.tsx
+++ b/src/components/page-components/AboutPage/AboutPage.tsx
@@ -7,6 +7,7 @@ import "./AboutPage.css"
 import { sendToBackground } from "@plasmohq/messaging"
 
 import BackButton from "~components/BackButton/BackButton"
+import Footer from "~components/Footer/Footer"
 import type { AboutPage } from "~types/baseTypes"
 
 export default function AboutPage() {
@@ -60,6 +61,7 @@ export default function AboutPage() {
           <p className="bold">all rights reserved to arebyte 2024</p>
         </div>
       </main>
+      <Footer />
     </div>
   )
 }

--- a/src/components/page-components/AboutPage/AboutPage.tsx
+++ b/src/components/page-components/AboutPage/AboutPage.tsx
@@ -1,12 +1,18 @@
+import { BlocksRenderer } from "@strapi/blocks-react-renderer"
 import { useEffect, useState } from "react"
 import { useErrorBoundary } from "react-error-boundary"
 
+import "./AboutPage.css"
+
 import { sendToBackground } from "@plasmohq/messaging"
 
+import BackButton from "~components/BackButton/BackButton"
 import type { AboutPage } from "~types/baseTypes"
 
 export default function AboutPage() {
-  const [content, setContent] = useState("")
+  const [content, setContent] = useState<AboutPage | undefined>(
+    undefined
+  )
   const { showBoundary } = useErrorBoundary()
 
   useEffect(() => {
@@ -21,16 +27,39 @@ export default function AboutPage() {
 
       if (error) return showBoundary(error)
 
-      setContent(data.abstract)
+      setContent(data)
     }
 
     getContent()
   }, [])
 
   return (
-    <>
-      <h1>ABOUT</h1>
-      {content && <p>{content}</p>}
-    </>
+    <div className="about-page page">
+      <main className="grid">
+        <BackButton />
+        {content && (
+          <div className="about-page--content content-box shadow stack">
+            <section>
+              <p className="bold text-md">About</p>
+              <p className="bold text-md">{content.abstract}</p>
+            </section>
+            <section>
+              <BlocksRenderer content={content.description} />
+            </section>
+          </div>
+        )}
+        <div className="about-page--credits content-box shadow stack">
+          <p className="bold">Credits</p>
+          <p className="bold">
+            Powered by <a href="https://www.arebyte.com/">arebyte</a>,
+            2024
+          </p>
+          <p className="bold">
+            Plugin Design and Development by enBloc
+          </p>
+          <p className="bold">all rights reserved to arebyte 2024</p>
+        </div>
+      </main>
+    </div>
   )
 }

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -10,6 +10,7 @@ import { useStorage } from "@plasmohq/storage/hook"
 import ErrorFallback from "~components/ErrorFallback/ErrorFallback"
 import HomePage from "~components/HomePage/HomePage"
 import Layout from "~components/Layout/Layout"
+import AboutPage from "~components/page-components/AboutPage/AboutPage"
 import CurrentProjectPage from "~components/page-components/CurrentProjectPage/CurrentProjectPage"
 import ExplorePage from "~components/page-components/ExplorePage/ExplorePage"
 import ExploreProjectPage from "~components/page-components/ExploreProjectPage/ExploreProjectPage"
@@ -108,6 +109,15 @@ function IndexPopup() {
           unmountOnExit
         >
           <FavouritesPage />
+        </CSSTransition>
+
+        <CSSTransition
+          in={currentPage === "about"}
+          timeout={500}
+          classNames="about-page"
+          unmountOnExit
+        >
+          <AboutPage />
         </CSSTransition>
       </Layout>
     </ErrorBoundary>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -5,10 +5,8 @@ import type { User } from "~types/userTypes"
 
 import createSelectors from "./createSelectors"
 
-export type PlayList = typeof baseStore<State["user"]["favourites"]>
-
 interface State {
-  user: User
+  user: Omit<User, "favourites">
   currentProject: ProjectData
   isLoggedIn: boolean
   exploreProjectId: number
@@ -44,8 +42,7 @@ const initialState: State = {
     is_paused: false,
     project_id: 0,
     current_index: 0,
-    event_time: "12:00:00.000",
-    favourites: []
+    event_time: "12:00:00.000"
   },
   isLoggedIn: false,
   currentPage: "home",

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -22,6 +22,7 @@ interface State {
     | "current-project"
     | "explore-project"
     | "favourites"
+    | "about"
 }
 
 interface Actions {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -5,7 +5,7 @@ import type { User } from "~types/userTypes"
 
 import createSelectors from "./createSelectors"
 
-export type PlayList = typeof baseStore<State["user"]["playlist"]>
+export type PlayList = typeof baseStore<State["user"]["favourites"]>
 
 interface State {
   user: User
@@ -45,7 +45,7 @@ const initialState: State = {
     project_id: 0,
     current_index: 0,
     event_time: "12:00:00.000",
-    playlist: []
+    favourites: []
   },
   isLoggedIn: false,
   currentPage: "home",

--- a/src/types/baseTypes.ts
+++ b/src/types/baseTypes.ts
@@ -1,3 +1,5 @@
+import { BlocksContent } from "@strapi/blocks-react-renderer"
+
 export interface Meta {
   pagination: {
     page: number
@@ -5,4 +7,10 @@ export interface Meta {
     pageSize: number
     total: number
   }
+}
+
+export interface AboutPage {
+  id: number
+  abstract: string
+  description: BlocksContent
 }


### PR DESCRIPTION
# Description

**Closes #45**  

This pr is dependent on the new content type introduced to the cms in a [pr there](https://github.com/enBloc-org/arebyte-plugin-backend/pull/27#issue-2623512230).

Creates an 'About' page and populates it with the data from this new single-page content type.

### Files changed

- `page-components/AboutPage/**` - new Page component to display the `about` information
- `background/messages/fetchAboutContent.ts` - new message handler to fetch the content of about-page on the cms
- `baseTypes.ts` - added an `AboutPage` interface for the response type of the new handler
- `BurgerMenu.tsx`, `store.ts` && `popup.tsx` add navigation to the new `AboutPage.tsx` component in the UI

#### Refactor

Adjusted the declarations in `store.ts` to set the initial state to contain `favourites` instead of `playlist` to match the new data structure on the cms

### UI changes

<img width="368" alt="Screenshot 2024-10-30 at 10 58 46" src="https://github.com/user-attachments/assets/5fc063a5-295c-4dce-bc03-f46d6aef31a9">
<img width="374" alt="Screenshot 2024-10-30 at 11 00 18" src="https://github.com/user-attachments/assets/babbd510-82e5-4394-a71b-3cdd2ac2b584">

### Changes to Documentation

n/a

# Tests

The new fetch call is tested with bruno in the new cms pr.
