### PR TITLE
#78/fix content script

### DIFF
--- a/src/utils/popup-utils/backgroundPopCreate.ts
+++ b/src/utils/popup-utils/backgroundPopCreate.ts
@@ -21,9 +21,13 @@ const backgroundPopupCreate = async (popups: Popup[]) => {
         action: "getScreenDimensions"
       })
     )
-    .catch(error => {
+    .catch(async error => {
       console.error(error)
-      return { width: 1920, height: 1080 }
+      const currentWindow = await Browser.windows.getCurrent()
+      return {
+        width: currentWindow.width,
+        height: currentWindow.height
+      }
     })
 
   const { width: screenWidth, height: screenHeight } =

--- a/src/utils/popup-utils/backgroundPopCreate.ts
+++ b/src/utils/popup-utils/backgroundPopCreate.ts
@@ -21,6 +21,11 @@ const backgroundPopupCreate = async (popups: Popup[]) => {
         action: "getScreenDimensions"
       })
     )
+    .catch(error => {
+      console.error(error)
+      return { width: 1920, height: 1080 }
+    })
+
   const { width: screenWidth, height: screenHeight } =
     screenDimensions as { width: number; height: number }
 


### PR DESCRIPTION
# Description

**Closes #78**  

Sets a `.catch` declaration on the `Browser.tabs` request so that in the event of tabs not being accessible we log that error and return the values of the window size instead.

### Files changed

`backgroundPopCreate.ts`

### UI changes

n/a

### Changes to Documentation

n/a

# Tests

n/a - the behaviour is the same, we're just covering an edge case that previous led to `sequences` not being triggered.
Tested manually by triggering the popups from within the `manage extensions` tab.
