### PR TITLE
#85/fix project card display

### DIFF
--- a/src/components/ProjectCards/ProjectCard.css
+++ b/src/components/ProjectCards/ProjectCard.css
@@ -15,6 +15,11 @@
   scale: 0.97;
   transition: scale 100ms ease;
 }
+.project-card h3 {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
 
 .project-card span {
   font-weight: 300;

--- a/src/components/page-components/ExplorePage/ExplorePage.css
+++ b/src/components/page-components/ExplorePage/ExplorePage.css
@@ -3,6 +3,11 @@
   animation-name: slideDown;
 }
 
+.explore-page--card-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
 .explore-page-enter {
   z-index: 3;
 }

--- a/src/components/page-components/ExplorePage/ExplorePage.tsx
+++ b/src/components/page-components/ExplorePage/ExplorePage.tsx
@@ -48,7 +48,7 @@ export default function ExplorePage() {
         <div className="explore-section">
           <h2 className="text-lg">EXPLORE</h2>
           {projects && (
-            <div className="flex gap margin-top-sm explore-card-container">
+            <div className="gap margin-top-sm explore-page--card-container">
               {projects.map(project => (
                 <ProjectCard key={project.id} project={project} />
               ))}


### PR DESCRIPTION
# Description

**Closes #85**  

Stops the `ProjectCard`s displayed from varying in height when the title of a project is longer than one line of text.

### Files changed

- `ExplorePage.tsx` && `ExplorePage.css` - turned the display of `ProjectCard`s in the `ExplorePage` from flex into a grid
- `ProjectCard.css` - set the text in the project title to hide any overflow with ellipsis if the content extends past one line of text

### UI changes

<img width="373" alt="Screenshot 2024-10-30 at 12 56 47" src="https://github.com/user-attachments/assets/01a0d161-1c67-4842-b502-91f11cd17e89">


### Changes to Documentation

n/a

# Tests

n/a - the behaviour of the code is the same, this is a styling issue
