### PR TITLE
style: edit project thumbnail display size and object fit

### DIFF
--- a/src/components/HomePage/HomePage.css
+++ b/src/components/HomePage/HomePage.css
@@ -43,6 +43,8 @@
 
 .home-project-thumbnail img {
   width: 100%;
+  height: 183px;
+  object-fit: cover;
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
 }

--- a/src/components/page-components/CurrentProjectPage/CurrentProjectPage.css
+++ b/src/components/page-components/CurrentProjectPage/CurrentProjectPage.css
@@ -24,3 +24,9 @@
   top: 1.25rem;
   left: 1.25rem;
 }
+
+.current-project--image {
+  min-width: 380px;
+  max-height: 230px;
+  object-fit: cover;
+}

--- a/src/components/page-components/CurrentProjectPage/CurrentProjectPage.tsx
+++ b/src/components/page-components/CurrentProjectPage/CurrentProjectPage.tsx
@@ -23,6 +23,7 @@ const CurrentProjectPage = () => {
             currentProject.cover_image.alternativeText ||
             "Project image thumbnail"
           }
+          className="current-project--image"
         />
         <div className="grid project-details__container">
           <ProjectDetails project={currentProject} />

--- a/src/components/page-components/ExploreProjectPage/ExploreProjectPage.tsx
+++ b/src/components/page-components/ExploreProjectPage/ExploreProjectPage.tsx
@@ -44,6 +44,7 @@ const ExploreProjectPage = () => {
               project.cover_image.formats.small.url
             }
             alt={project.cover_image.alternativeText || project.title}
+            className="explore-project-image"
           />
           <div className="grid project-details__container">
             <ProjectDetails project={project} />


### PR DESCRIPTION
# Description

**Closes #94**  

Fixes the styling of the project thumbnails in the `HomePage`, `CurrentProjectPage` and `ExploreProjectPage`.

### Files changed

- `HomePage.css`, `ExplorePage.tsx`, `CurrentProjectPage.tsx` and `CurrentProjectPage.css` - added explicit styling for the thumbnail images with the height, width and object-fit

### UI changes

All pages now keep this thumbnail styling regardless of the dimensions of the image used.

<img width="373" alt="Screenshot 2024-10-31 at 10 50 04" src="https://github.com/user-attachments/assets/29e51337-23b4-4ce4-b1a8-d4cf5d0a197f">


### Changes to Documentation

n/a

# Tests

n/a
