### PR TITLE
99/favourites hotfix

### DIFF
--- a/src/background/messages/fetchCurrentProject.ts
+++ b/src/background/messages/fetchCurrentProject.ts
@@ -8,6 +8,12 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   const response = await fetchStrapiContent<CurrentProjectData>(
     `api/current-project?${currentProjectQueryString}`
   )
+
+  if (response.error) {
+    console.error(response.error)
+    res.send(response)
+  }
+
   res.send(response)
 }
 

--- a/src/background/messages/manuallyTriggerEventAlarm.ts
+++ b/src/background/messages/manuallyTriggerEventAlarm.ts
@@ -6,7 +6,6 @@ import eventAlarmListener from "~utils/eventAlarmListener"
 
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   const alarm = await Browser.alarms.get("sequence-alarm")
-  console.log(alarm)
   await eventAlarmListener(alarm)
 
   res.send("ok")

--- a/src/components/HomePage/HomePage.tsx
+++ b/src/components/HomePage/HomePage.tsx
@@ -61,7 +61,7 @@ export default function HomePage() {
               <p className="container-label">UP NEXT</p>
               <div className="stack home-up-next-description">
                 <h2 className="text-lg">
-                  {currentProject.events[current_index].title}
+                  {currentProject.sequence[current_index].title}
                 </h2>
                 <table>
                   <tbody>
@@ -77,7 +77,7 @@ export default function HomePage() {
                       <td>Day:</td>
                       <td>
                         {current_index + 1} of{" "}
-                        {currentProject.events.length}
+                        {currentProject.sequence.length}
                       </td>
                     </tr>
                   </tbody>

--- a/src/components/page-components/FavouritesPage/FavouritesPage.css
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.css
@@ -41,3 +41,9 @@
   grid-template-rows: 1fr 1fr 1fr;
   gap: 15px;
 }
+
+.favourites-page--message__no-favourites {
+  grid-column: 1/3;
+  height: 320px;
+  margin-top: 30px;
+}

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -42,6 +42,10 @@ export default function FavouritesPage() {
       })
 
     if (error) return showBoundary(error)
+
+    setFavouritesList(previous =>
+      previous.filter(favourite => favourite.id !== givenId)
+    )
   }
 
   useEffect(() => {
@@ -96,7 +100,7 @@ export default function FavouritesPage() {
 
       setFavouritesList(popupData)
     }
-    console.log("use effect")
+
     getFavourites()
   }, [setFavouritesList, pageNumber])
 

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -68,10 +68,12 @@ export default function FavouritesPage() {
         return showBoundary(
           "Something went wrong. Please try again later."
         )
+      if (favouritesData.favourites.length === 0) return
 
       const targetArray: number[] = favouritesData.favourites.map(
         favourite => favourite.id
       )
+
       const {
         data: popupData,
         error: popupError,
@@ -89,13 +91,14 @@ export default function FavouritesPage() {
       })
 
       if (popupError) return showBoundary(popupError)
+      if (meta.pagination.pageCount !== 1)
+        setPageCount(meta.pagination.pageCount)
 
-      setPageCount(meta.pagination.pageCount)
       setFavouritesList(popupData)
     }
-
+    console.log("use effect")
     getFavourites()
-  }, [setFavouritesList, pageNumber, handlePopupRemove])
+  }, [setFavouritesList, pageNumber])
 
   return (
     <div className="page favourites-page">

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -119,7 +119,7 @@ export default function FavouritesPage() {
           favourites
         </p>
 
-        {favouritesList && (
+        {favouritesList.length > 0 ? (
           <div className="favourites-page--favourites-grid">
             {favouritesList.map(favourite => (
               <div key={favourite.id}>
@@ -133,6 +133,11 @@ export default function FavouritesPage() {
               </div>
             ))}
           </div>
+        ) : (
+          <p className="bold text-lg favourites-page--message__no-favourites">
+            There are no favourites available. You can mark a pop-up
+            as a favourite during your next scheduled event.
+          </p>
         )}
       </main>
       <PaginationNav

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -30,20 +30,18 @@ export default function FavouritesPage() {
     setIsEditing(previous => !previous)
   }
 
-  const handlePopupRemove = async givenId => {
-    const updatedFavourites = favouritesList.filter(
-      favourite => favourite.id !== givenId
-    )
-
+  const handlePopupRemove = async (givenId: number) => {
     const { error }: { error: string | null } =
       await sendToBackground({
         name: "updateUserDetails",
-        body: { favourites: updatedFavourites }
+        body: {
+          favourites: {
+            disconnect: givenId
+          }
+        }
       })
 
     if (error) return showBoundary(error)
-
-    setFavouritesList(updatedFavourites)
   }
 
   useEffect(() => {
@@ -97,7 +95,7 @@ export default function FavouritesPage() {
     }
 
     getFavourites()
-  }, [setFavouritesList, pageNumber])
+  }, [setFavouritesList, pageNumber, handlePopupRemove])
 
   return (
     <div className="page favourites-page">

--- a/src/queries/currentProjectQuery.ts
+++ b/src/queries/currentProjectQuery.ts
@@ -9,14 +9,14 @@ const currentProjectQuery = {
         cover_image: {
           fields: ["*"]
         },
-        events: {
+        sequence: {
           fields: ["*"]
         },
         content_creator: {
           fields: ["curator_name", "curator_organisation", "bio"],
           populate: {
             organisation_logo: {
-              fields: ["*"],
+              fields: ["*"]
             },
             upcoming_events: {
               fields: ["*"]

--- a/src/queries/projectQuery.ts
+++ b/src/queries/projectQuery.ts
@@ -6,7 +6,7 @@ const projectQuery = {
     cover_image: {
       fields: ["*"]
     },
-    events: {
+    sequence: {
       fields: ["*"]
     },
     content_creator: {

--- a/src/types/projectTypes.ts
+++ b/src/types/projectTypes.ts
@@ -17,7 +17,7 @@ export interface ProjectData {
   description: BlocksContent
   cover_image: ImageResponse
   launch_date: string
-  events: Omit<EventData, "pop_ups">[]
+  sequence: Omit<EventData, "pop_ups">[]
   content_creator: ContentCreator
 }
 

--- a/src/utils/getCurrentProjectPopups.ts
+++ b/src/utils/getCurrentProjectPopups.ts
@@ -16,7 +16,7 @@ export default async function getCurrentProjectPopups(
     `api/current-project?${currentProjectQueryString}`
   )
   const currentEventId =
-    currentProject.data.project.events[currentIndex].id
+    currentProject.data.project.sequence[currentIndex].id
   const {
     data: { pop_ups }
   } = await fetchStrapiContent<EventData>(
@@ -24,6 +24,6 @@ export default async function getCurrentProjectPopups(
   )
   return {
     pop_ups: pop_ups,
-    numberOfEvents: currentProject.data.project.events.length
+    numberOfEvents: currentProject.data.project.sequence.length
   }
 }

--- a/src/utils/getProjectPopups.ts
+++ b/src/utils/getProjectPopups.ts
@@ -16,7 +16,7 @@ export default async function getProjectPopups(
   const currentProject = await fetchStrapiContent<ProjectData>(
     `api/projects/${projectId}?${projectQueryString}`
   )
-  const currentEventId = currentProject.data.events[currentIndex].id
+  const currentEventId = currentProject.data.sequence[currentIndex].id
   const {
     data: { pop_ups }
   } = await fetchStrapiContent<EventData>(
@@ -25,6 +25,6 @@ export default async function getProjectPopups(
 
   return {
     pop_ups: pop_ups,
-    numberOfEvents: currentProject.data.events.length
+    numberOfEvents: currentProject.data.sequence.length
   }
 }


### PR DESCRIPTION
# Description

**Closes #99**  

Stops the favourites page from slipping into an infinite reload.
Replaced all references to `events` with `sequence` to match our new data structure.
Set a user notification to be displayed when there are no favourites selected.

### Files changed

- `page-components/FavouritesPage/**` - refactored the useEffect that fetches the user favourites and made the `handlePopupRemove` function reset the local state
- `**Types.ts` - corrected different types to match the new data structure by calling `sequence` instead of `events`
- cleared several debugging console.logs that had been overlooked

### UI changes

<img width="377" alt="Screenshot 2024-10-31 at 17 49 06" src="https://github.com/user-attachments/assets/55dcdba0-7eba-4f40-9a33-364066284abe">


### Changes to Documentation

n/a

# Tests

n/a
