### PR TITLE
98/hotfix paused timer

### DIFF
--- a/src/components/page-components/ProfilePage/ProfilePage.tsx
+++ b/src/components/page-components/ProfilePage/ProfilePage.tsx
@@ -1,13 +1,11 @@
 import { Form, Formik } from "formik"
-import { useErrorBoundary } from "react-error-boundary"
 import * as Yup from "yup"
 
 import useStore from "~store/store"
 import newStorage from "~utils/newStorage"
 
 import "./ProfilePage.css"
-
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 import { sendToBackground } from "@plasmohq/messaging"
 
@@ -15,7 +13,7 @@ import BurgerMenu from "~components/BurgerMenu/BurgerMenu"
 import Footer from "~components/Footer/Footer"
 import FormInput from "~components/Forms/PasswordInput/FormInput"
 import ToggleSwitch from "~components/ToggleSwitch/ToggleSwitch"
-import type { User, UserSession } from "~types/userTypes"
+import type { User } from "~types/userTypes"
 import formatTimeString from "~utils/formatTimeString"
 
 export default function ProfilePage() {
@@ -25,32 +23,10 @@ export default function ProfilePage() {
   const userInfo = useStore.use.user()
   const { is_paused: isPaused } = useStore.use.user()
   const updatedIsPaused = useStore.use.updateIsPaused()
-  const updateUser = useStore.use.updateUser()
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [errorMessage, setErrorMessage] = useState<string>("")
   const [pausedStateError, setPausedStateError] = useState<string>("")
-  const { showBoundary } = useErrorBoundary()
-
-  useEffect(() => {
-    const getUserDetails = async () => {
-      const userSession: UserSession = await storage.get(
-        "arebyte-audience-session"
-      )
-      const { data, error }: { data: User; error: string | null } =
-        await sendToBackground({
-          name: "fetchUserProfile",
-          body: { jwt: userSession.jwt, id: userSession.id }
-        })
-
-      if (error) showBoundary(error)
-      updateUser(data)
-    }
-
-    if (userInfo.username === undefined) {
-      getUserDetails()
-    }
-  }, [])
 
   const handlePausedSwitchClick = async () => {
     const { data, error }: { data: User; error: string | null } =

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 import { CSSTransition } from "react-transition-group"
 
+import { sendToBackground } from "@plasmohq/messaging"
 import { useStorage } from "@plasmohq/storage/hook"
 
 import ErrorFallback from "~components/ErrorFallback/ErrorFallback"
@@ -19,7 +20,7 @@ import LoginPage from "~components/page-components/LoginPage/LoginPage"
 import ProfilePage from "~components/page-components/ProfilePage/ProfilePage"
 import SignUpPage from "~components/page-components/SignUpPage/SignUpPage"
 import useStore from "~store/store"
-import { UserSession } from "~types/userTypes"
+import type { User, UserSession } from "~types/userTypes"
 import newStorage from "~utils/newStorage"
 
 function IndexPopup() {
@@ -33,7 +34,19 @@ function IndexPopup() {
   })
 
   useEffect(() => {
-    if (userSession) updateUser(userSession)
+    const fetchUserProfile = async () => {
+      if (userSession) {
+        const { data, error }: { data: User; error: string | null } =
+          await sendToBackground({
+            name: "fetchUserProfile",
+            body: { jwt: userSession.jwt, id: userSession.id }
+          })
+        console.log(data)
+        if (error) console.error(error)
+        updateUser(data)
+      }
+    }
+    fetchUserProfile()
   }, [userSession])
 
   return (


### PR DESCRIPTION
# Description

**Closes #98**

This PR resolved the issue where the timer component didn't know the state of the user paused setting by shifting where the database call was happening to update the user information in the store to the main popup component.  


### Files changed
-```src/components/page-components/ProfilePage/ProfilePage.tsx``` - removes unneeded db call
- ```src/popup.tsx``` - adds db call to update store based on session info
