### PR TITLE
Footer and styling issue on explore and favourites page

### DIFF
--- a/src/components/BurgerMenu/BurgerMenu.css
+++ b/src/components/BurgerMenu/BurgerMenu.css
@@ -1,4 +1,4 @@
-*:has(.burger--logo__active) {
+.page:has(.burger--logo__active) {
   overflow: hidden;
 }
 
@@ -7,6 +7,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 20px;
+  width: 380px;
 }
 
 .burger--heading img {

--- a/src/components/FilterTags/FilterTags.css
+++ b/src/components/FilterTags/FilterTags.css
@@ -1,6 +1,7 @@
 .tags-container {
   flex-wrap: wrap;
   align-items: center;
+  position: relative;
   gap: 0.625rem;
   grid-row: 1/2;
   width: 340px;
@@ -25,4 +26,6 @@
 
 .button--clear {
   align-self: flex-end;
+  position: absolute;
+  top: 180px;
 }

--- a/src/components/FilterTags/FilterTags.css
+++ b/src/components/FilterTags/FilterTags.css
@@ -27,5 +27,5 @@
 .button--clear {
   align-self: flex-end;
   position: absolute;
-  top: 180px;
+  bottom: -25px;
 }

--- a/src/components/FilterTags/FilterTags.tsx
+++ b/src/components/FilterTags/FilterTags.tsx
@@ -45,7 +45,7 @@ const FilterTags: React.FC<FilterTagsProps> = ({
   }
 
   return (
-    <div className="flex flex-column gap">
+    <div className="flex flex-column relative">
       <div className="flex tags-container">
         {tags &&
           tags.map(tag => {

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -4,6 +4,7 @@
   align-items: center;
   min-height: 60px;
   width: 100%;
+  max-width: 380px;
   padding: 0 1.25rem;
   margin-top: .5rem;
 }

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -13,6 +13,8 @@ body {
   position: absolute;
   top: 0;
   left: 0;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
   height: 100dvh;
   width: 100dvw;
   animation-duration: 0.8s;

--- a/src/components/globals.css
+++ b/src/components/globals.css
@@ -234,6 +234,10 @@ button:disabled {
   font-weight: bold;
 }
 
-.uppercase{
+.uppercase {
   text-transform: uppercase;
+}
+
+.relative {
+  position: relative;
 }

--- a/src/components/page-components/ExplorePage/ExplorePage.css
+++ b/src/components/page-components/ExplorePage/ExplorePage.css
@@ -3,6 +3,10 @@
   animation-name: slideDown;
 }
 
+.explore-main {
+    padding: .625rem;
+}
+
 .explore-page--card-container {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -25,7 +29,8 @@
 }
 
 .explore-section {
-  grid-row: 3/4;
+  grid-row: 2/4;
+  margin-top: 1.25rem;
 }
 
 .explore-card-container {

--- a/src/components/page-components/ExplorePage/ExplorePage.css
+++ b/src/components/page-components/ExplorePage/ExplorePage.css
@@ -4,7 +4,7 @@
 }
 
 .explore-main {
-    padding: .625rem;
+    padding: 1.25rem;
 }
 
 .explore-page--card-container {
@@ -29,7 +29,6 @@
 }
 
 .explore-section {
-  grid-row: 2/4;
   margin-top: 1.25rem;
 }
 

--- a/src/components/page-components/ExplorePage/ExplorePage.tsx
+++ b/src/components/page-components/ExplorePage/ExplorePage.tsx
@@ -58,14 +58,16 @@ export default function ExplorePage() {
               ))}
             </div>
           )}
-          <PaginationNav
-            pageNumber={pageNumber}
-            pageCount={pageCount}
-            setterFunction={setPageNumber}
-          />
         </div>
       </main>
-      <Footer />
+      <div>
+        <PaginationNav
+          pageNumber={pageNumber}
+          pageCount={pageCount}
+          setterFunction={setPageNumber}
+        />
+        <Footer />
+      </div>
     </div>
   )
 }

--- a/src/components/page-components/ExplorePage/ExplorePage.tsx
+++ b/src/components/page-components/ExplorePage/ExplorePage.tsx
@@ -44,7 +44,7 @@ export default function ExplorePage() {
   return (
     <div className="explore-page page">
       <BurgerMenu />
-      <main className="grid">
+      <main className="explore-main">
         <FilterTags
           activeTags={activeTags}
           setActiveTags={setActiveTags}

--- a/src/components/page-components/FavouritesPage/FavouritesPage.css
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.css
@@ -3,6 +3,10 @@
   animation-name: slideLeft;
 }
 
+.favourites-main {
+  padding: 0 1.25rem;
+}
+
 .favourites-page-enter {
   z-index: 3;
 }
@@ -20,29 +24,24 @@
 }
 
 .favourites-page--toggle-pair {
-  grid-column: 1;
-  grid-row: 1;
   display: flex;
-  flex-direction: row;
   align-items: center;
-  justify-content: space-between;
+  gap: 0.625rem;
 }
 
 .favourites-page--title {
-  grid-row: 2;
-  margin-bottom: -15px;
+  margin-top: 1.25rem;
+  font-size: .85rem;
 }
 
 .favourites-page--favourites-grid {
-  grid-column: 1/3;
-  height: fit-content;
+  margin-top: .625rem;
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 15px;
 }
 
 .favourites-page--message__no-favourites {
-  grid-column: 1/3;
   height: 320px;
   margin-top: 30px;
 }

--- a/src/components/page-components/FavouritesPage/FavouritesPage.css
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.css
@@ -38,7 +38,6 @@
   height: fit-content;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr 1fr;
   gap: 15px;
 }
 

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -105,7 +105,7 @@ export default function FavouritesPage() {
   }, [setFavouritesList, pageNumber])
 
   return (
-    <div className="page favourites-page">
+    <div className="favourites-page page">
       <BurgerMenu />
       <main className="grid">
         <div className="favourites-page--toggle-pair">
@@ -140,12 +140,14 @@ export default function FavouritesPage() {
           </p>
         )}
       </main>
-      <PaginationNav
-        pageNumber={pageNumber}
-        pageCount={pageCount}
-        setterFunction={setPageNumber}
-      />
-      <Footer />
+     <div>
+       <PaginationNav
+         pageNumber={pageNumber}
+         pageCount={pageCount}
+         setterFunction={setPageNumber}
+       />
+       <Footer />
+     </div>
     </div>
   )
 }

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -107,7 +107,7 @@ export default function FavouritesPage() {
   return (
     <div className="favourites-page page">
       <BurgerMenu />
-      <main className="grid">
+      <main className="favourites-main">
         <div className="favourites-page--toggle-pair">
           <ToggleSwitch
             clickHandler={handleToggleSwitch}
@@ -115,39 +115,40 @@ export default function FavouritesPage() {
           />
           <p className="bold uppercase">edit favourites</p>
         </div>
-        <p className="bold uppercase favourites-page--title">
-          favourites
-        </p>
-
-        {favouritesList.length > 0 ? (
-          <div className="favourites-page--favourites-grid">
-            {favouritesList.map(favourite => (
-              <div key={favourite.id}>
-                <PopupCard
-                  popup={favourite}
-                  isEditing={isEditing}
-                  removeButtonHandler={() =>
-                    handlePopupRemove(favourite.id)
-                  }
-                />
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="bold text-lg favourites-page--message__no-favourites">
-            There are no favourites available. You can mark a pop-up
-            as a favourite during your next scheduled event.
-          </p>
-        )}
+        <section>
+          <h2 className="bold uppercase favourites-page--title">
+            favourites
+          </h2>
+          {favouritesList.length > 0 ? (
+            <div className="favourites-page--favourites-grid">
+              {favouritesList.map(favourite => (
+                <div key={favourite.id}>
+                  <PopupCard
+                    popup={favourite}
+                    isEditing={isEditing}
+                    removeButtonHandler={() =>
+                      handlePopupRemove(favourite.id)
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-lg favourites-page--message__no-favourites">
+              There are no favourites available. You can mark a pop-up
+              as a favourite during your next scheduled event.
+            </p>
+          )}
+        </section>
       </main>
-     <div>
-       <PaginationNav
-         pageNumber={pageNumber}
-         pageCount={pageCount}
-         setterFunction={setPageNumber}
-       />
-       <Footer />
-     </div>
+      <div>
+        <PaginationNav
+          pageNumber={pageNumber}
+          pageCount={pageCount}
+          setterFunction={setPageNumber}
+        />
+        <Footer />
+      </div>
     </div>
   )
 }

--- a/src/components/page-components/ProfilePage/ProfilePage.css
+++ b/src/components/page-components/ProfilePage/ProfilePage.css
@@ -2,6 +2,10 @@
   animation-name: slideRight;
 }
 
+.profile-page--main {
+    padding: 0 1.25rem
+}
+
 .profile-page--user-details {
   grid-column: 1/3;
   height: fit-content;
@@ -50,6 +54,7 @@
   height: 65px;
   justify-content: space-evenly;
   transition: all 0.3s ease-out;
+  margin-top: 1.5rem;
 }
 
 .profile-page--controls[aria-hidden="true"] {

--- a/src/components/page-components/ProfilePage/ProfilePage.tsx
+++ b/src/components/page-components/ProfilePage/ProfilePage.tsx
@@ -60,7 +60,7 @@ export default function ProfilePage() {
     userInfo && (
       <div className="profile-page page background__stripped">
         <BurgerMenu />
-        <main className="grid profile-page--main">
+        <main className="profile-page--main">
           <div className="content-box shadow profile-page--user-details">
             <h3 className="profile-page--user-name">
               {userInfo.username}


### PR DESCRIPTION
# Description

**Closes #102**  
This PR covers styling fixes on the explore and favourites page
- Makes sure footer and pagination are correctly display at the bottom of the screen
- fixes edge case when using grid that push content down weirdly to the middle of the screen.


### Files changed
-```FilterTags.tsx/css``` - makes the clear button absolute so it doesn't push down content
-```BurgerMenu.css``` - fixes sudo class to fix burger menu
- ```globals.css``` - adds relative global class
- ```ExplorePage.css/tsx``` - fixes grid issue when tags click pushed down content
- ```FavouritesPage.tsx/css``` - fixes footer placement and fixes edge case that pushed card to the middle when there two or fewer.
