### PR TITLE
#112/loading favourites

### DIFF
--- a/src/components/WithLoading/WithLoading.css
+++ b/src/components/WithLoading/WithLoading.css
@@ -1,5 +1,11 @@
+.with-loading--container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: auto;
+}
+
 .with-loading__loading {
-  height: 100px;
   width: 300px;
   animation: blink 3s ease-in-out infinite;
 }

--- a/src/components/WithLoading/WithLoading.css
+++ b/src/components/WithLoading/WithLoading.css
@@ -1,0 +1,15 @@
+.with-loading__loading {
+  height: 100px;
+  width: 300px;
+  animation: blink 3s ease-in-out infinite;
+}
+
+@keyframes blink {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}

--- a/src/components/WithLoading/WithLoading.tsx
+++ b/src/components/WithLoading/WithLoading.tsx
@@ -2,7 +2,17 @@ import logo from "data-base64:assets/arebyte-Plugin-blue.png"
 
 import "./WithLoading.css"
 
-export default function WithLoading({ children, isLoading }) {
+/**
+ *
+ * @returns a new component that wraps the children with a loading state dynamically controlled by the isLoading boolean
+ */
+export default function WithLoading({
+  children,
+  isLoading
+}: {
+  children: JSX.Element
+  isLoading: boolean
+}) {
   if (isLoading)
     return <img className="with-loading__loading" src={logo} />
 

--- a/src/components/WithLoading/WithLoading.tsx
+++ b/src/components/WithLoading/WithLoading.tsx
@@ -14,7 +14,11 @@ export default function WithLoading({
   isLoading: boolean
 }) {
   if (isLoading)
-    return <img className="with-loading__loading" src={logo} />
+    return (
+      <div className="with-loading--container">
+        <img className="with-loading__loading" src={logo} />
+      </div>
+    )
 
   return <div>{children}</div>
 }

--- a/src/components/WithLoading/WithLoading.tsx
+++ b/src/components/WithLoading/WithLoading.tsx
@@ -1,0 +1,10 @@
+import logo from "data-base64:assets/arebyte-Plugin-blue.png"
+
+import "./WithLoading.css"
+
+export default function WithLoading({ children, isLoading }) {
+  if (isLoading)
+    return <img className="with-loading__loading" src={logo} />
+
+  return <div>{children}</div>
+}

--- a/src/components/page-components/ExplorePage/ExplorePage.tsx
+++ b/src/components/page-components/ExplorePage/ExplorePage.tsx
@@ -11,6 +11,7 @@ import FilterTags from "~components/FilterTags/FilterTags"
 import Footer from "~components/Footer/Footer"
 import PaginationNav from "~components/PaginationNav/PaginationNav"
 import ProjectCard from "~components/ProjectCards/ProjectCard"
+import WithLoading from "~components/WithLoading/WithLoading"
 import type { Meta } from "~types/baseTypes"
 import { TagData, type ProjectData } from "~types/projectTypes"
 
@@ -20,9 +21,11 @@ export default function ExplorePage() {
   const [pageCount, setPageCount] = useState<number>(1)
   const { showBoundary } = useErrorBoundary()
   const [activeTags, setActiveTags] = useState<TagData[]>([])
+  const [isLoading, setIsLoading] = useState<boolean>(true)
 
   useEffect(() => {
     const fetchAllProjects = async () => {
+      setIsLoading(true)
       const {
         data,
         error,
@@ -37,6 +40,7 @@ export default function ExplorePage() {
 
       setPageCount(meta.pagination.pageCount)
       setProjects(data)
+      setIsLoading(false)
     }
     fetchAllProjects()
   }, [pageNumber, activeTags, setActiveTags])
@@ -49,16 +53,18 @@ export default function ExplorePage() {
           activeTags={activeTags}
           setActiveTags={setActiveTags}
         />
-        <div className="explore-section">
-          <h2 className="text-lg">EXPLORE</h2>
-          {projects && (
-            <div className="gap margin-top-sm explore-page--card-container">
-              {projects.map(project => (
-                <ProjectCard key={project.id} project={project} />
-              ))}
-            </div>
-          )}
-        </div>
+        <WithLoading isLoading={isLoading}>
+          <div className="explore-section">
+            <h2 className="text-lg">EXPLORE</h2>
+            {projects && (
+              <div className="gap margin-top-sm explore-page--card-container">
+                {projects.map(project => (
+                  <ProjectCard key={project.id} project={project} />
+                ))}
+              </div>
+            )}
+          </div>
+        </WithLoading>
       </main>
       <div>
         <PaginationNav

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -11,6 +11,7 @@ import Footer from "~components/Footer/Footer"
 import PaginationNav from "~components/PaginationNav/PaginationNav"
 import PopupCard from "~components/PopupCard/PopupCard"
 import ToggleSwitch from "~components/ToggleSwitch/ToggleSwitch"
+import WithLoading from "~components/WithLoading/WithLoading"
 import { Meta } from "~types/baseTypes"
 import type { Favourite } from "~types/eventTypes"
 import type { UserFavourites, UserSession } from "~types/userTypes"
@@ -24,6 +25,7 @@ export default function FavouritesPage() {
   >([])
   const [pageNumber, setPageNumber] = useState<number>(1)
   const [pageCount, setPageCount] = useState<number>(1)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
   const storage = newStorage()
 
   const handleToggleSwitch = () => {
@@ -50,6 +52,7 @@ export default function FavouritesPage() {
 
   useEffect(() => {
     const getFavourites = async () => {
+      setIsLoading(true)
       const userSession: UserSession = await storage.get(
         "arebyte-audience-session"
       )
@@ -99,6 +102,7 @@ export default function FavouritesPage() {
         setPageCount(meta.pagination.pageCount)
 
       setFavouritesList(popupData)
+      setIsLoading(false)
     }
 
     getFavourites()
@@ -115,31 +119,34 @@ export default function FavouritesPage() {
           />
           <p className="bold uppercase">edit favourites</p>
         </div>
-        <section>
-          <h2 className="bold uppercase favourites-page--title">
-            favourites
-          </h2>
-          {favouritesList.length > 0 ? (
-            <div className="favourites-page--favourites-grid">
-              {favouritesList.map(favourite => (
-                <div key={favourite.id}>
-                  <PopupCard
-                    popup={favourite}
-                    isEditing={isEditing}
-                    removeButtonHandler={() =>
-                      handlePopupRemove(favourite.id)
-                    }
-                  />
-                </div>
-              ))}
-            </div>
-          ) : (
-            <p className="text-lg favourites-page--message__no-favourites">
-              There are no favourites available. You can mark a pop-up
-              as a favourite during your next scheduled event.
-            </p>
-          )}
-        </section>
+        <WithLoading isLoading={isLoading}>
+          <section>
+            <h2 className="bold uppercase favourites-page--title">
+              favourites
+            </h2>
+            {favouritesList.length > 0 ? (
+              <div className="favourites-page--favourites-grid">
+                {favouritesList.map(favourite => (
+                  <div key={favourite.id}>
+                    <PopupCard
+                      popup={favourite}
+                      isEditing={isEditing}
+                      removeButtonHandler={() =>
+                        handlePopupRemove(favourite.id)
+                      }
+                    />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-lg favourites-page--message__no-favourites">
+                There are no favourites available. You can mark a
+                pop-up as a favourite during your next scheduled
+                event.
+              </p>
+            )}
+          </section>
+        </WithLoading>
       </main>
       <div>
         <PaginationNav


### PR DESCRIPTION
# Description

**Closes #112**

Creates a new higher order component that wraps any children given to it with the logic to handle a loading state.

I've applied this new component to both the `Favourites` and the `Explore` page as they both handle similar loading of a lot of data. This component flashes the logo in assets while we load because I thought that would be a more personalised look than just adding a spinner - but that's very much under question I think.

### Files changed

- `components/WithLoading/` - new component plus styling
- `FavouritesPage.tsx` and `ExplorePage.tsx` - import the new `WithLoading` component and wrap the elements displaying fetched data in it

### UI changes

The pages look exactly the same, but if you throttle the app you'll see the arebyte logo flashing for a few seconds before the data is loaded

### Changes to Documentation

n/a

# Tests

n/a - no changes to the logic in the code
