### PR TITLE
#107/pagination nav redesign

### DIFF
--- a/src/components/PaginationNav/PaginationNav.css
+++ b/src/components/PaginationNav/PaginationNav.css
@@ -2,6 +2,8 @@
   display: flex;
   justify-content: space-evenly;
   align-items: center;
-  margin-left: 50%;
+  margin: 0 auto;
   margin-top: 10px;
+  margin-bottom: -10px;
+  width: 150px;
 }

--- a/src/components/PaginationNav/PaginationNav.tsx
+++ b/src/components/PaginationNav/PaginationNav.tsx
@@ -22,19 +22,19 @@ export default function PaginationNav({
   return (
     <div className="pagination-nav">
       <button
-        className="button--secondary"
+        className="button--secondary text-md"
         onClick={navigateToPrevious}
         disabled={pageNumber === 1}
       >
-        previous
+        {"<<<"}
       </button>
-      <p className="bold">{`${pageNumber} of ${pageCount}`}</p>
+      <p className="bold text-lg">{`${pageNumber} of ${pageCount}`}</p>
       <button
-        className="button--secondary"
+        className="button--secondary text-md"
         onClick={navigateToNext}
         disabled={pageNumber === pageCount}
       >
-        next
+        {">>>"}
       </button>
     </div>
   )

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -106,7 +106,7 @@ export default function FavouritesPage() {
     }
 
     getFavourites()
-  }, [setFavouritesList, pageNumber])
+  }, [setFavouritesList, pageNumber, favouritesList.length % 6 === 0])
 
   return (
     <div className="favourites-page page">

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -43,13 +43,13 @@ export default function FavouritesPage() {
 
     if (error) return showBoundary(error)
 
-    setFavouritesList(previous =>
-      previous.filter(favourite => favourite.id !== givenId)
+    const newFavourites = favouritesList.filter(
+      favourite => favourite.id !== givenId
     )
-    if (favouritesList.length % 6 === 0) {
-      setPageNumber(1)
-      setPageCount(previous => previous - 1)
-    }
+    if (newFavourites.length === 0)
+      setPageNumber(previous => previous - 1)
+
+    setFavouritesList(newFavourites)
   }
 
   useEffect(() => {
@@ -99,14 +99,14 @@ export default function FavouritesPage() {
       })
 
       if (popupError) return showBoundary(popupError)
-      if (meta.pagination.pageCount !== 1)
+      if (meta.pagination.pageCount !== pageCount)
         setPageCount(meta.pagination.pageCount)
 
       setFavouritesList(popupData)
     }
 
     getFavourites()
-  }, [setFavouritesList, pageNumber, favouritesList.length % 6 === 0])
+  }, [setFavouritesList, pageNumber])
 
   return (
     <div className="favourites-page page">

--- a/src/components/page-components/FavouritesPage/FavouritesPage.tsx
+++ b/src/components/page-components/FavouritesPage/FavouritesPage.tsx
@@ -46,6 +46,10 @@ export default function FavouritesPage() {
     setFavouritesList(previous =>
       previous.filter(favourite => favourite.id !== givenId)
     )
+    if (favouritesList.length % 6 === 0) {
+      setPageNumber(1)
+      setPageCount(previous => previous - 1)
+    }
   }
 
   useEffect(() => {
@@ -102,7 +106,7 @@ export default function FavouritesPage() {
     }
 
     getFavourites()
-  }, [setFavouritesList, pageNumber])
+  }, [setFavouritesList, pageNumber, favouritesList.length % 6 === 0])
 
   return (
     <div className="favourites-page page">


### PR DESCRIPTION
# Description

**Closes #122**
**Closes #107**
  
Re-styles the `PaginationNav` component and introduces a fix to the pagination bug reported for `FavouritesPage`

### Files changed

- `components/PaginationNav/**` - updated the styling of this component to match the new figma design
- `FavouritesPage.tsx` - updated the `useEffect` dependency array and refactored the logic on `handlePopupRemove` to enforce a re-render of the list when deleting a popup reduces the total list to a multiple of 6 or to 0

### UI changes

<img width="377" alt="Screenshot 2024-11-11 at 15 56 43" src="https://github.com/user-attachments/assets/efc89908-6577-4605-86a0-919733ee44ad">

### Changes to Documentation

n/a

# Tests

n/a
