### PR TITLE
style: define flex grow and shrink behaviour for tags

### DIFF
--- a/src/components/FilterTags/FilterTags.css
+++ b/src/components/FilterTags/FilterTags.css
@@ -11,7 +11,12 @@
   border: 1px solid var(--highlight);
   border-radius: 1.25rem;
   padding: 0.625rem;
-  min-width: 40px;
+  flex-basis: 25px;
+  flex-grow: 1;
+  flex-shrink: 1;
+  white-space: nowrap;
+  text-align: center;
+  cursor: pointer;
 }
 
 .button--filter:hover {


### PR DESCRIPTION
# Description

**Closes #108**

Re-styles the display of filtering `tags` in the `ExplorePage`. Naughtily this does not follow the new figma design because that design didn't actually foresee the possibility of really large or very tiny tag titles - instead, I've tweaked the existing `flex` display so that tags can grow or shrink slightly and try to keep a uniform and tiddy-looking display overall.

### Files changed

- `FilterTags.css` - set new flex properties

### UI changes

<img width="372" alt="Screenshot 2024-11-11 at 17 13 39" src="https://github.com/user-attachments/assets/13c3cb06-6f2d-4c76-b3a3-35d2ebd2fd4f">
I tried to set some wildcard tag names to see how this would behave and it seems to generally fall into a nice combination, but have a go at setting different ones on your end. I also always tested it with 10 different tags since that's what our meetings seemed to indicate these will be kept at.

### Changes to Documentation

n/a

# Tests

n/a
