### PR TITLE
#106/profile redesign

### DIFF
--- a/src/components/page-components/ProfilePage/ProfilePage.css
+++ b/src/components/page-components/ProfilePage/ProfilePage.css
@@ -27,6 +27,15 @@
   transition: all 0.3s ease-in-out;
 }
 
+.profile-page--input-pair {
+  margin: 7px 0;
+}
+
+.profile-page--form .input-message__error {
+  margin-left: 10px;
+  margin-top: 3px;
+}
+
 .profile-page--form label {
   margin-left: 10px;
 }
@@ -37,7 +46,7 @@
   opacity: 0;
 }
 
-.profile-page--form > input {
+.profile-page--form input {
   width: 318px;
   height: 36px;
   color: black;
@@ -50,6 +59,10 @@
   justify-content: space-between;
   align-items: center;
   grid-row: 3;
+}
+
+.profile-page--button__submit {
+  margin: 7px 0;
 }
 
 .profile-page--controls {

--- a/src/components/page-components/ProfilePage/ProfilePage.css
+++ b/src/components/page-components/ProfilePage/ProfilePage.css
@@ -3,14 +3,13 @@
 }
 
 .profile-page--main {
-    padding: 0 1.25rem
+  padding: 0 1.25rem;
 }
 
 .profile-page--user-details {
   grid-column: 1/3;
   height: fit-content;
   min-height: 5.5rem;
-  max-height: 420px;
   display: grid;
   grid-row: 1fr auto 1fr;
   z-index: 0;
@@ -22,10 +21,14 @@
 }
 
 .profile-page--form {
-  height: 330px;
+  height: 400px;
   align-items: start;
   justify-content: space-evenly;
   transition: all 0.3s ease-in-out;
+}
+
+.profile-page--form label {
+  margin-left: 10px;
 }
 
 .profile-page--form[aria-hidden="true"] {

--- a/src/components/page-components/ProfilePage/ProfilePage.tsx
+++ b/src/components/page-components/ProfilePage/ProfilePage.tsx
@@ -5,6 +5,7 @@ import useStore from "~store/store"
 import newStorage from "~utils/newStorage"
 
 import "./ProfilePage.css"
+
 import { useState } from "react"
 
 import { sendToBackground } from "@plasmohq/messaging"
@@ -35,7 +36,10 @@ export default function ProfilePage() {
         name: "updateUserDetails",
         body: { is_paused: !isPaused }
       })
-    if (error) setPausedStateError("Something went wrong. Please try again later.")
+    if (error)
+      setPausedStateError(
+        "Something went wrong. Please try again later."
+      )
     updatedIsPaused(!isPaused)
 
     if (!isPaused) {
@@ -45,7 +49,10 @@ export default function ProfilePage() {
         name: "updateEventAlarm",
         body: { eventHour: selectedHour, eventMinute: selectedMinute }
       })
-      if (error) setPausedStateError("Something went wrong. Please try again later.")
+      if (error)
+        setPausedStateError(
+          "Something went wrong. Please try again later."
+        )
     } else {
       await sendToBackground({ name: "removeEventAlarm" })
     }
@@ -164,7 +171,9 @@ export default function ProfilePage() {
                   name="birth_date"
                   type="date"
                 />
-                <label htmlFor="location">Location</label>
+                <label htmlFor="location">
+                  Location (where you live)
+                </label>
                 <FormInput
                   placeholder={userInfo.location}
                   name="location"
@@ -197,7 +206,7 @@ export default function ProfilePage() {
             </Formik>
             <div className="profile-page--modal-buttons">
               <button
-                className={`${isOpen ? "profile-page--arrow-button__open" : "profile-page--arrow-button"}`}
+                className={`bold ${isOpen ? "profile-page--arrow-button__open" : "profile-page--arrow-button"}`}
                 aria-controls="account-settings"
                 onClick={() => setIsOpen(previous => !previous)}
               >
@@ -217,7 +226,11 @@ export default function ProfilePage() {
               </button>
 
               {isOpen && (
-                <button type="button" onClick={handleLogOff}>
+                <button
+                  type="button"
+                  onClick={handleLogOff}
+                  className="bold"
+                >
                   Log me out
                 </button>
               )}

--- a/src/components/page-components/ProfilePage/ProfilePage.tsx
+++ b/src/components/page-components/ProfilePage/ProfilePage.tsx
@@ -85,11 +85,11 @@ export default function ProfilePage() {
               enableReinitialize={true}
               validationSchema={Yup.object({
                 username: Yup.string()
-                  .min(3, "Must be longer then 3 characters")
+                  .min(3, "Must be longer than 3 characters")
                   .max(15, "Must be 15 characters or less")
                   .required("Required"),
                 email: Yup.string()
-                  .min(6, "Must be longer then 6 characters")
+                  .min(6, "Must be longer than 6 characters")
                   .email("Invalid email address")
                   .required("Required"),
                 location: Yup.string()
@@ -153,45 +153,55 @@ export default function ProfilePage() {
                 className="profile-page--form flex flex-column"
                 aria-hidden={!isOpen}
               >
-                <label htmlFor="username">Username</label>
-                <FormInput
-                  placeholder={userInfo.username}
-                  name="username"
-                  type="text"
-                />
-                <label htmlFor="email">Email address</label>
-                <FormInput
-                  placeholder={userInfo.email}
-                  name="email"
-                  type="email"
-                />
-                <label htmlFor="birth_date">Date of birth</label>
-                <FormInput
-                  placeholder={userInfo.birth_date}
-                  name="birth_date"
-                  type="date"
-                />
-                <label htmlFor="location">
-                  Location (where you live)
-                </label>
-                <FormInput
-                  placeholder={userInfo.location}
-                  name="location"
-                  type="text"
-                />
-                <label htmlFor="event_time">
-                  Your preferred time to receive popups
-                </label>
-                <FormInput
-                  placeholder={userInfo.event_time}
-                  name="event_time"
-                  type="time"
-                  isDisabled={userInfo.is_paused}
-                />
+                <div className="profile-page--input-pair">
+                  <label htmlFor="username">Username</label>
+                  <FormInput
+                    placeholder={userInfo.username}
+                    name="username"
+                    type="text"
+                  />
+                </div>
+                <div className="profile-page--input-pair">
+                  <label htmlFor="email">Email address</label>
+                  <FormInput
+                    placeholder={userInfo.email}
+                    name="email"
+                    type="email"
+                  />
+                </div>
+                <div className="profile-page--input-pair">
+                  <label htmlFor="birth_date">Date of birth</label>
+                  <FormInput
+                    placeholder={userInfo.birth_date}
+                    name="birth_date"
+                    type="date"
+                  />
+                </div>
+                <div className="profile-page--input-pair">
+                  <label htmlFor="location">
+                    Location (where you live)
+                  </label>
+                  <FormInput
+                    placeholder={userInfo.location}
+                    name="location"
+                    type="text"
+                  />
+                </div>
+                <div className="profile-page--input-pair">
+                  <label htmlFor="event_time">
+                    Your preferred time to receive popups
+                  </label>
+                  <FormInput
+                    placeholder={userInfo.event_time}
+                    name="event_time"
+                    type="time"
+                    isDisabled={userInfo.is_paused}
+                  />
+                </div>
                 <div className="flex gap">
                   <button
                     type="submit"
-                    className="button--primary"
+                    className="button--primary profile-page--button__submit"
                     disabled={isLoading}
                   >
                     submit


### PR DESCRIPTION
# Description

**Closes #106**  

Re-styles the `ProfilePage` so it looks luscious like the new figma

### Files changed

- `ProfilePage.tsx` - wrapped all `input`-`label` pairs in a new class to create space in the form for the error messages that were not accounted for in the design
- `ProfilePage.css` - overrides some of the global form styling in this page because this forms behaves slightly different from the rest. The fields require labels that crowd the form substantially, so I've manipulated the margins a bit to compensate and keep a balanced look

### UI changes

<img width="378" alt="Screenshot 2024-11-12 at 12 14 56" src="https://github.com/user-attachments/assets/75a83e63-999b-4e10-8139-053e4c544993">


### Changes to Documentation

n/a

# Tests

n/a
