### PR TITLE
style: control info--container dimensions to maintain syling when pop…

### DIFF
--- a/src/components/popup-components/PopupInfo/PopupInfo.css
+++ b/src/components/popup-components/PopupInfo/PopupInfo.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 body:has(.info-panel__active) {
   background-color: #0017f8;
   transition: background-color 0.5s ease-out 0.5s;
@@ -19,6 +23,8 @@ button {
 }
 
 .info--container {
+  width: 100%;
+  min-height: fit-content;
   display: grid;
   color: #fff;
   padding: 4rem 3rem;
@@ -59,6 +65,7 @@ button {
 
 .info-description {
   margin-top: 2rem;
+  width: 80%;
   font-size: 0.9rem;
   font-weight: 300;
   line-height: 1.4;


### PR DESCRIPTION
# Description

**Closes #114**  

Tweaks the styling of our popups slightly to maintain the appearance of the information panel across size changes while avoiding the previous bug where the content would be visible behind the blue information screen

### Files changed

- `PopupInfo.css` - applies `border-box` to all elements, emulating our global settings, and determines a `min-height` for the information description element

### UI changes

Everything looks the same as before, it's only been made more consistent through size changes. Opening any popup and stretching / shrinking the window should no longer break the original styling.

### Changes to Documentation

n/a

# Tests

n/a
