### PR TITLE
#135/aspect ratio

### DIFF
--- a/src/__tests__/parseAspectRatio.test.js
+++ b/src/__tests__/parseAspectRatio.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "@jest/globals"
+
+import parseAspectRatio from "../utils/popup-utils/parseAspectRatio.ts"
+
+describe("parseAspectRation", () => {
+  it("returns a number calculated based on the aspect ratio described in the string passed in", () => {
+    const squareRatio = parseAspectRatio("square (4:3)")
+    const rectangularRatio = parseAspectRatio("rectangular (16:9)")
+
+    expect(squareRatio).toBe(4 / 3)
+    expect(rectangularRatio).toBe(16 / 9)
+  })
+
+  it("returns the value of 16:9 aspect ratio as a default if the passed string is invalid", () => {
+    const failingRatio = parseAspectRatio("invalid string")
+
+    expect(failingRatio).toBe(16 / 9)
+  })
+})

--- a/src/__tests__/parseWindowSize.test.js
+++ b/src/__tests__/parseWindowSize.test.js
@@ -2,7 +2,7 @@ import { describe, expect, it } from "@jest/globals"
 
 import parseWindowSize from "~utils/popup-utils/parseWindowSize"
 
-describe("parseWindoSize", () => {
+describe("parseWindowSize", () => {
   const SCREEN_WIDTH = 1920
   it("should return a width and height for small (.3 ratio) value in a 16/9 aspect ratio", () => {
     const smallResult = parseWindowSize("small", SCREEN_WIDTH)
@@ -20,7 +20,11 @@ describe("parseWindoSize", () => {
   })
 
   it("should return a costume aspect ratio", () => {
-    const customResult = parseWindowSize("small", SCREEN_WIDTH, 4 / 3)
+    const customResult = parseWindowSize(
+      "small",
+      SCREEN_WIDTH,
+      "square (4:3)"
+    )
     expect(customResult).toEqual({ width: 576, height: 432 })
   })
 

--- a/src/types/eventTypes.ts
+++ b/src/types/eventTypes.ts
@@ -13,6 +13,7 @@ export interface EventData {
 
 export interface MediaContent {
   id: number
+  aspect_ratio: "square (4:3)" | "rectangular (16:9)"
   __component: "piece.piece"
   description: BlocksContent
   media: ImageResponse | VideoResponse

--- a/src/utils/popup-utils/backgroundPopCreate.ts
+++ b/src/utils/popup-utils/backgroundPopCreate.ts
@@ -109,7 +109,8 @@ const backgroundPopupCreate = async (
           {
             const { width, height } = parseWindowSize(
               popup.popup_size,
-              screenWidth
+              screenWidth,
+              popup.popup_content[0].aspect_ratio
             )
             const { top, left } = calculatePopupCoordinates(
               popup,

--- a/src/utils/popup-utils/displayPopup.ts
+++ b/src/utils/popup-utils/displayPopup.ts
@@ -86,7 +86,8 @@ export default async function displayPopup(popup: Popup) {
       case "video": {
         const { width, height } = parseWindowSize(
           popup.popup_size,
-          screenWidth
+          screenWidth,
+          popup.popup_content[0].aspect_ratio
         )
         const { top, left } = calculatePopupCoordinates(
           popup,

--- a/src/utils/popup-utils/parseAspectRatio.ts
+++ b/src/utils/popup-utils/parseAspectRatio.ts
@@ -1,0 +1,18 @@
+/**
+ *
+ * @description the CMS sets the aspect ratio of videos in a descriptive string that needs to be searched for the correct ratio pattern and calculated based on those converted values
+ * @param aspectRatioSetting i.e.: "rectangular (16:9)"
+ * @returns the aspect ratio calculated out of the width and height described in the given string
+ */
+export default function parseAspectRatio(
+  aspectRatioSetting: string
+): number {
+  const ratioExpression = new RegExp(/([1-9]{1,2}:[1-9]{1,2})/)
+  const ratioPattern = aspectRatioSetting.match(ratioExpression)?.[0]
+
+  if(!ratioPattern) return 16 / 9
+
+  const [width, height] = ratioPattern.split(":")
+
+  return parseInt(width) / parseInt(height)
+}

--- a/src/utils/popup-utils/parseWindowSize.ts
+++ b/src/utils/popup-utils/parseWindowSize.ts
@@ -1,3 +1,5 @@
+import parseAspectRatio from "./parseAspectRatio"
+
 /**
  * @description Parse the size of a window
  * @param {string} size - the size of the window
@@ -5,15 +7,16 @@
  * @param {number} aspectRatio - the aspect ratio of the window, default to 16/9
  * @returns {object} - the width and height of the window
  */
-
 const parseWindowSize = (
   size: string,
   screenWidth: number,
-  aspectRatio: number = 16 / 9
+  aspectRatio: string = "rectangular (16:9)"
 ): { width: number; height: number } => {
+  const ratio = parseAspectRatio(aspectRatio)
+
   const calculateDimensions = (factor: number) => {
     const width = Math.floor(screenWidth * factor)
-    const height = Math.floor(width / aspectRatio)
+    const height = Math.floor(width / ratio)
     return { width, height }
   }
 
@@ -27,7 +30,7 @@ const parseWindowSize = (
     default:
       return {
         width: 600,
-        height: Math.floor(600 / aspectRatio)
+        height: Math.floor(600 / ratio)
       }
   }
 }


### PR DESCRIPTION
# Description

**Closes #135**  

This pr is dependent on the changes in the outstanding [PR on the backend](https://github.com/enBloc-org/arebyte-plugin-backend/pull/59#issue-2659125690)

### Files changed

- `utils/popup-utils/parseAspectRatio.ts` -  because the backend will only allow a drop down selector for string values (which must include characters besides numbers), this util will take any string that includes a recognisable aspect ratio in it (i.e.: 4:3) and parse that out and return the calculated ratio
- `parseWindowSize.ts` - now expects a string for the `aspectRatio` and calls `parseAspectRatio.ts` to return the appropriate ratio calculated
- `backgroundPopCreate.ts` && `displayPopup.ts`- both take the new `aspect_ratio` property from the popups and pass them to `parseWindowSize.ts` if the type of content is "video"
- `types/eventTypes.ts` - extend the types system to reflect the new property for `MediaContent`

### UI changes

It all looks the same except the window size for popups will match what's been chosen in the CMS. The ratio will default to `16:9` if nothing has been passed or if the content type is an image or text.

### Changes to Documentation

n/a

# Tests

- `parseWindowSize.test.js` - one of the tests was checking the return value for a call where the aspect ratio is explicitly passed. This was adjusted as the argument type is no longer a `number` but a `string`
- `parseAspectRatio.test.js` - new test suite for the new util
