### PR TITLE
fix: edit button render evaluation to always display optional buttons…

### DIFF
--- a/src/components/BurgerMenu/BurgerMenu.tsx
+++ b/src/components/BurgerMenu/BurgerMenu.tsx
@@ -76,15 +76,17 @@ export default function BurgerMenu() {
           )}
           <button
             className="button--secondary text-xl"
-            onClick={() => handleNavigate("favourites")}
-            disabled={!isLoggedIn}
+            onClick={() =>
+              handleNavigate(isLoggedIn ? "favourites" : "login")
+            }
           >
             favourites
           </button>
           <button
             className="button--secondary text-xl"
-            onClick={() => handleNavigate("digest")}
-            disabled={!isLoggedIn}
+            onClick={() =>
+              handleNavigate(isLoggedIn ? "digest" : "login")
+            }
           >
             digest
           </button>

--- a/src/components/BurgerMenu/BurgerMenu.tsx
+++ b/src/components/BurgerMenu/BurgerMenu.tsx
@@ -65,18 +65,6 @@ export default function BurgerMenu() {
               >
                 my account
               </button>
-              <button
-                className="button--secondary text-xl"
-                onClick={() => handleNavigate("favourites")}
-              >
-                favourites
-              </button>
-              <button
-                className="button--secondary text-xl"
-                onClick={() => handleNavigate("digest")}
-              >
-                digest
-              </button>
             </>
           ) : (
             <button
@@ -86,6 +74,20 @@ export default function BurgerMenu() {
               LOGIN
             </button>
           )}
+          <button
+            className="button--secondary text-xl"
+            onClick={() => handleNavigate("favourites")}
+            disabled={!isLoggedIn}
+          >
+            favourites
+          </button>
+          <button
+            className="button--secondary text-xl"
+            onClick={() => handleNavigate("digest")}
+            disabled={!isLoggedIn}
+          >
+            digest
+          </button>
         </div>
         <div className="burger--contact">
           <div>


### PR DESCRIPTION
# Description

**Closes #138**  

Re-arranges the display of the `BurgerMenu` to show the optional areas of the extension as disabled navigation options when logged out.

### Files changed

- `BurgerMenu.tsx`- the buttons already had a styling set for their `disabled` state so they just had to be moved outside of the ternary statement and given the `isLoggedIn` boolean as the value of their `disabled` attribute

### UI changes

<img width="378" alt="Screenshot 2024-11-15 at 07 34 20" src="https://github.com/user-attachments/assets/bc73a87e-857b-4579-a0ba-547b6113ff4e">

<img width="377" alt="Screenshot 2024-11-15 at 07 34 49" src="https://github.com/user-attachments/assets/a507e334-85e6-4a39-b81b-5b2d65fd877a">

### Changes to Documentation

n/a

# Tests

n/a