### PR TITLE
139/fav button fix

### DIFF
--- a/src/components/popup-components/ManageFavouritesButton/ManageFavouritesButton.tsx
+++ b/src/components/popup-components/ManageFavouritesButton/ManageFavouritesButton.tsx
@@ -7,6 +7,7 @@ import newStorage from "~utils/newStorage"
 
 const ManageFavouritesButton = ({ popupId }) => {
   const storage = newStorage()
+  const [hasUserSession, setHasUserSession] = useState<boolean>(false)
   const [status, setStatus] = useState<
     "idle" | "loading" | "rejected"
   >("idle")
@@ -17,6 +18,11 @@ const ManageFavouritesButton = ({ popupId }) => {
       const userSession: UserSession = await storage.get(
         "arebyte-audience-session"
       )
+      if (!userSession) {
+        setHasUserSession(false)
+        return
+      }
+      setHasUserSession(true)
       const {
         data,
         error
@@ -31,7 +37,8 @@ const ManageFavouritesButton = ({ popupId }) => {
 
       if (error) {
         console.error(error)
-        return setStatus("rejected")
+        setStatus("rejected")
+        return
       }
       setIsFavourite(data.favourites.some(fav => fav.id === popupId))
     }
@@ -60,20 +67,26 @@ const ManageFavouritesButton = ({ popupId }) => {
   }
 
   return (
-    <div className="controls-button--container">
-      <button
-        className="info--button"
-        disabled={status === "loading"}
-        onClick={clickHandler}
-      >
-        {isFavourite ? "REMOVE FROM FAVOURITES" : "ADD TO FAVOURITES"}
-      </button>
-      {status === "rejected" && (
-        <p className="controls-message__error">
-          Something went wrong, try again.
-        </p>
+    <>
+      {hasUserSession && (
+        <div className="controls-button--container">
+          <button
+            className="info--button"
+            disabled={status === "loading"}
+            onClick={clickHandler}
+          >
+            {isFavourite
+              ? "REMOVE FROM FAVOURITES"
+              : "ADD TO FAVOURITES"}
+          </button>
+          {status === "rejected" && (
+            <p className="controls-message__error">
+              Something went wrong, try again.
+            </p>
+          )}
+        </div>
       )}
-    </div>
+    </>
   )
 }
 

--- a/src/components/popup-components/PopupInfo/PopupInfo.css
+++ b/src/components/popup-components/PopupInfo/PopupInfo.css
@@ -118,7 +118,7 @@ button:focus {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 250px;
+  width: 275px;
 }
 
 /* Styles for buttons controls in info panel */


### PR DESCRIPTION
# Description

**Closes #139 **  
Include here a short description of what behaviour this Pull Request introduces.
Outline any new dependencies introduced.

This pull request includes several changes to the `ManageFavouritesButton` component and a small CSS adjustment in the `PopupInfo` component.

Improvements to `ManageFavouritesButton` component:

* Added a new state `hasUserSession` to track if a user session exists. (`src/components/popup-components/ManageFavouritesButton/ManageFavouritesButton.tsx`)
* Updated the logic to check for a user session and set the `hasUserSession` state accordingly. (`src/components/popup-components/ManageFavouritesButton/ManageFavouritesButton.tsx`)
* Updated the component rendering to conditionally display the button controls only if a user session exists. (`src/components/popup-components/ManageFavouritesButton/ManageFavouritesButton.tsx`)

CSS adjustment:

* Increased the width of buttons in the `PopupInfo` component from 250px to 275px. (`src/components/popup-components/PopupInfo/PopupInfo.css`)

### UI changes

<img width="499" alt="Screenshot 2024-11-15 at 11 27 30" src="https://github.com/user-attachments/assets/f9c536dd-eda4-44f1-94b1-827733eaab4d">

<img width="787" alt="Screenshot 2024-11-15 at 11 29 35" src="https://github.com/user-attachments/assets/039ed4ec-4b9a-45e5-b743-cc4f431a4121">

